### PR TITLE
Minor TShell bug fix and clean-up

### DIFF
--- a/pkg.info/package.json
+++ b/pkg.info/package.json
@@ -109,57 +109,64 @@
   },
   "publish": {
     "current": {
-      "comment": "Feature adds to TShell, Data model, and enable default constructors for BETTER_ENUMs",
-      "version": "4.3.0",
-      "date": "Fri Dec 23 03:14:02 2022",
-      "timestamp": 1671765242,
-      "changes": "\"Add unit test for the Wifi-Station interface (though no concrete impl in colony.core)\\nEnable default constructors for BETTER_ENUMs\\nTShell refactored to support user login and three permission levels\\nAdd 'settling-time' feature to the Data Model's Persistent Records\\nRefactor Data Model Array MPs (array MPs are now typed ONLY by their element type)\\nRefactor String MPs (String MPs are now a single type)\\nAdd readAndSync() and isNotInvalidAndSync() method to properly synchronous Observers when the MP data is read in the change notification callback\\n\""
+      "comment": "Minor bug fix/clean-up to the TShell",
+      "version": "4.3.1",
+      "date": "Sun Jan 15 21:00:19 2023",
+      "timestamp": 1673816419,
+      "changes": "\"- Fix bug where the quote/escape characters where not being set correctly for the TShell Maker objects. \\n- Clean-up help strings \\n- Make base TShell command security aware\\n\""
     },
     "history": [
-        {
-            "comment": "Add additional driver support and non-blocking TCP socket streams",
-            "version": "4.2.2",
-            "date": "Sun Nov  6 23:15:51 2022",
-            "timestamp": 1667776551,
-            "changes": "\"- Add interface for WIFI Station functionality\\n- Add the ability to read 'out-of-band' input in the command shell.\\n- Add additional JSON support.\\n- Add Nvram driver interface.\\n- Add I2C platform independent interface definition.\\n- Add support for CAT24C512 EEPROM.\\n- Add non-blocking TCP socket interface and Win32 implementation\\n\""
-        },
-        {
-            "comment": "Minor bug fixes and external package updates",
-            "version": "4.2.1",
-            "date": "Sun Sep 11 18:56:47 2022",
-            "timestamp": 1662922607,
-            "changes": "\"- Fix bug in the missing 'blocking' argument for the frame decoders\\n- Fix issue of the Cpl::Io::Stream available() method reporting  mouse/focus events for stdin under Windoze\\n- Get the latest package version of: nqbp, colony.bsp, and colony.bsp.renesas.rx\\n\""
-        },
-        {
-            "comment": "Added new Drivers. Tweaked the StreamDecoder. Added VS solution. Added Null Media and RAM IO stream",
-            "version": "4.2.0",
-            "date": "Sun Sep  4 17:55:27 2022",
-            "timestamp": 1662314127
-        },
-        {
-            "comment": "Add Periodic Scheduler. Add non-blocking TShell processor",
-            "version": "4.1.0",
-            "date": "Thu Aug 18 01:03:06 2022",
-            "timestamp": 1660784586
-        },
-        {
-            "comment": "Refactor Model Points for smaller footprint (is a breaking change)",
-            "version": "3.0.0",
-            "date": "Mon May 30 18:11:49 2022",
-            "timestamp": 1653934309
-        },
-        {
-            "comment": "Try again at publishing as a Outcast2 package",
-            "version": "2.0.2",
-            "date": "Sun Nov 28 14:33:57 2021",
-            "timestamp": 1638110037
-        },
-        {
-            "comment": "Initial publish as a Outcast2 package",
-            "version": "2.0.1.",
-            "date": "Sat Nov 20 20:15:42 2021",
-            "timestamp": 1637439342
-        }
+      {
+        "comment": "Feature adds to TShell, Data model, and enable default constructors for BETTER_ENUMs",
+        "version": "4.3.0",
+        "date": "Fri Dec 23 03:14:02 2022",
+        "timestamp": 1671765242,
+        "changes": "\"Add unit test for the Wifi-Station interface (though no concrete impl in colony.core)\\nEnable default constructors for BETTER_ENUMs\\nTShell refactored to support user login and three permission levels\\nAdd 'settling-time' feature to the Data Model's Persistent Records\\nRefactor Data Model Array MPs (array MPs are now typed ONLY by their element type)\\nRefactor String MPs (String MPs are now a single type)\\nAdd readAndSync() and isNotInvalidAndSync() method to properly synchronous Observers when the MP data is read in the change notification callback\\n\""
+      },
+      {
+        "comment": "Add additional driver support and non-blocking TCP socket streams",
+        "version": "4.2.2",
+        "date": "Sun Nov  6 23:15:51 2022",
+        "timestamp": 1667776551,
+        "changes": "\"- Add interface for WIFI Station functionality\\n- Add the ability to read 'out-of-band' input in the command shell.\\n- Add additional JSON support.\\n- Add Nvram driver interface.\\n- Add I2C platform independent interface definition.\\n- Add support for CAT24C512 EEPROM.\\n- Add non-blocking TCP socket interface and Win32 implementation\\n\""
+      },
+      {
+        "comment": "Minor bug fixes and external package updates",
+        "version": "4.2.1",
+        "date": "Sun Sep 11 18:56:47 2022",
+        "timestamp": 1662922607,
+        "changes": "\"- Fix bug in the missing 'blocking' argument for the frame decoders\\n- Fix issue of the Cpl::Io::Stream available() method reporting  mouse/focus events for stdin under Windoze\\n- Get the latest package version of: nqbp, colony.bsp, and colony.bsp.renesas.rx\\n\""
+      },
+      {
+        "comment": "Added new Drivers. Tweaked the StreamDecoder. Added VS solution. Added Null Media and RAM IO stream",
+        "version": "4.2.0",
+        "date": "Sun Sep  4 17:55:27 2022",
+        "timestamp": 1662314127
+      },
+      {
+        "comment": "Add Periodic Scheduler. Add non-blocking TShell processor",
+        "version": "4.1.0",
+        "date": "Thu Aug 18 01:03:06 2022",
+        "timestamp": 1660784586
+      },
+      {
+        "comment": "Refactor Model Points for smaller footprint (is a breaking change)",
+        "version": "3.0.0",
+        "date": "Mon May 30 18:11:49 2022",
+        "timestamp": 1653934309
+      },
+      {
+        "comment": "Try again at publishing as a Outcast2 package",
+        "version": "2.0.2",
+        "date": "Sun Nov 28 14:33:57 2021",
+        "timestamp": 1638110037
+      },
+      {
+        "comment": "Initial publish as a Outcast2 package",
+        "version": "2.0.1.",
+        "date": "Sat Nov 20 20:15:42 2021",
+        "timestamp": 1637439342
+      }
     ]
   }
 }

--- a/src/Cpl/Dm/Persistent/Record.h
+++ b/src/Cpl/Dm/Persistent/Record.h
@@ -48,7 +48,7 @@ public:
     typedef struct
     {
         Cpl::Dm::ModelPoint*                                        mpPtr;          //!< Pointer to a Model Point 
-        Cpl::Dm::SubscriberComposer<Record, Cpl::Dm::ModelPoint>*    observerPtr;    //!< Place holder to for dynamically allocated Subscriber Instance.  Note: A ZERO value will not allocate a subscriber
+        Cpl::Dm::SubscriberComposer<Record, Cpl::Dm::ModelPoint>*   observerPtr;    //!< Place holder to for dynamically allocated Subscriber Instance.  Note: A ZERO value will not allocate a subscriber
     } Item_T;
 
 public:

--- a/src/Cpl/Dm/TShell/Dm.cpp
+++ b/src/Cpl/Dm/TShell/Dm.cpp
@@ -21,8 +21,11 @@ using namespace Cpl::Dm::TShell;
 
 
 ///////////////////////////
-Dm::Dm( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Cpl::Dm::ModelDatabaseApi& modelDatabase, const char* cmdNameAndDatabaseNumber ) noexcept
-	: Cpl::TShell::Cmd::Command( commandList, cmdNameAndDatabaseNumber )
+Dm::Dm( Cpl::Container::Map<Cpl::TShell::Command>&  commandList,
+		Cpl::Dm::ModelDatabaseApi&                  modelDatabase,
+		const char*                                 cmdNameAndDatabaseNumber,
+		Cpl::TShell::Security::Permission_T         minPermLevel ) noexcept
+	: Cpl::TShell::Cmd::Command( commandList, cmdNameAndDatabaseNumber, minPermLevel )
 	, m_database( modelDatabase )
 {
 }

--- a/src/Cpl/Dm/TShell/Dm.h
+++ b/src/Cpl/Dm/TShell/Dm.h
@@ -17,29 +17,6 @@
 #include "Cpl/Dm/ModelDatabaseApi.h"
 
 
-
-/** Usage
-                                        "         1         2         3         4         5         6         7         8"
-                                        "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-*/
-#define CPLDMTSHELL_USAGE_DM_           "dm ls [<filter>]\n" \
-                                        "dm write {<mp-json>}\n" \
-                                        "dm read <mpname>\n" \
-                                        "dm touch <mpname>"
-
-/// Detailed Help text
-#ifndef CPLDMTSHELL_DETAIL_DM_
-#define CPLDMTSHELL_DETAIL_DM_          "  Lists, updates, and displays Model Points contained in the Model Database.\n" \
-                                        "  When 'ls' is used a list of model point names is returned.  The <filter>\n" \
-                                        "  argument will only list points that contain <filter>.  Updating a Model Point\n" \
-                                        "  is done by specifying a JSON object. See the concrete class definition of the\n" \
-                                        "  Model Point being updated for the JSON format.  When displaying a Model Point\n" \
-                                        "  <mpname> is the string name of the Model Point instance to be displayed."
-
-#endif // ifndef allows detailed help to be compacted down to a single character if FLASH/code space is an issue
-
-
-
 ///
 namespace Cpl {
 ///
@@ -57,6 +34,25 @@ namespace TShell {
  */
 class Dm : public Cpl::TShell::Cmd::Command
 {
+public:
+    /// The command usage string
+    static constexpr const char* usage = "dm ls [<filter>]\n" 
+                                         "dm write {<mp-json>}\n" 
+                                         "dm read <mpname>\n" 
+                                         "dm touch <mpname>";
+
+    /** The command detailed help string (recommended that lines do not exceed 80 chars)
+                                                          1         2         3         4         5         6         7         8
+                                                 12345678901234567890123456789012345678901234567890123456789012345678901234567890
+     */
+    static constexpr const char* detailedHelp = "  Lists, updates, and displays Model Points contained in the Model Database.\n" 
+                                                "  When 'ls' is used a list of model point names is returned.  The <filter>\n" 
+                                                "  argument will only list points that contain <filter>.  Updating a Model Point\n" 
+                                                "  is done by specifying a JSON object. See the concrete class definition of the\n" 
+                                                "  Model Point being updated for the JSON format.  When displaying a Model Point\n" 
+                                                "  <mpname> is the string name of the Model Point instance to be displayed.";
+
+
 protected:
     /// Model Point Database to access
     Cpl::Dm::ModelDatabaseApi& m_database;
@@ -64,15 +60,18 @@ protected:
     /// Dynamic 
 public:
     /// See Cpl::TShell::Command                                                               `
-    const char* getUsage() const noexcept { return CPLDMTSHELL_USAGE_DM_; }
+    const char* getUsage() const noexcept { return usage; }
 
     /// See Cpl::TShell::Command
-    const char* getHelp() const noexcept { return CPLDMTSHELL_DETAIL_DM_; }
+    const char* getHelp() const noexcept { return detailedHelp; }
 
 
 public:
     /// Constructor
-    Dm( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Cpl::Dm::ModelDatabaseApi& modelDatabase, const char* cmdNameAndDatabaseNumber="dm" ) noexcept;
+    Dm( Cpl::Container::Map<Cpl::TShell::Command>&  commandList, 
+        Cpl::Dm::ModelDatabaseApi&                  modelDatabase, 
+        const char*                                 cmdNameAndDatabaseNumber="dm",
+        Cpl::TShell::Security::Permission_T         minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 
 public:

--- a/src/Cpl/TShell/Cmd/Bye.cpp
+++ b/src/Cpl/TShell/Cmd/Bye.cpp
@@ -20,8 +20,9 @@
 using namespace Cpl::TShell::Cmd;
 
 ///////////////////////////
-Bye::Bye( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept
-	:Command( commandList, CPLTSHELLCMD_CMD_BYE_ )
+Bye::Bye( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+		  Security::Permission_T                     minPermLevel ) noexcept
+	:Command( commandList, verb, minPermLevel )
 {
 }
 

--- a/src/Cpl/TShell/Cmd/Bye.h
+++ b/src/Cpl/TShell/Cmd/Bye.h
@@ -15,23 +15,6 @@
 #include "colony_config.h"
 #include "Cpl/TShell/Cmd/Command.h"
 
-/** Command
-                                    "         1         2         3         4         5         6         7         8"
-                                    "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-*/
-#define CPLTSHELLCMD_CMD_BYE_		"bye"
-/// Usage
-#define CPLTSHELLCMD_USAGE_BYE_     "bye [app [<exitcode>]]"
-
-/// Detailed Help text
-#ifndef CPLTSHELLCMD_DETAIL_BYE_
-#define CPLTSHELLCMD_DETAIL_BYE_    "  Requests the  shell to exit. If the optional argument 'app' is specified\n" \
-                                    "  then the application is exited with the specifed <exitcode>. The default\n" \
-                                    "  <exitcode> is '0'."
-
-#endif // ifndef allows detailed help to be compacted down to a single character if FLASH/code space is an issue
-
-
 ///
 namespace Cpl {
 ///
@@ -43,17 +26,35 @@ namespace Cmd {
  */
 class Bye : public Command
 {
+public:
+    /// The command verb/identifier
+    static constexpr const char* verb = "bye";
+
+    /// The command usage string
+    static constexpr const char* usage = "bye [app [<exitcode>]]"
+                                         "bob on|off delay";
+
+    /** The command detailed help string (recommended that lines do not exceed 80 chars)
+                                                          1         2         3         4         5         6         7         8
+                                                 12345678901234567890123456789012345678901234567890123456789012345678901234567890
+     */
+    static constexpr const char* detailedHelp = "  Requests the  shell to exit. If the optional argument 'app' is specified\n" 
+                                                "  then the application is exited with the specifed <exitcode>. The default\n" 
+                                                "  <exitcode> is '0'.";
+
+
 protected:
     /// See Cpl::TShell::Command
-    const char* getUsage() const noexcept { return CPLTSHELLCMD_USAGE_BYE_; }
+    const char* getUsage() const noexcept { return usage; }
 
     /// See Cpl::TShell::Command
-    const char* getHelp() const noexcept { return CPLTSHELLCMD_DETAIL_BYE_; }
+    const char* getHelp() const noexcept { return detailedHelp; }
 
 
 public:
     /// Constructor
-    Bye( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept;
+    Bye( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+         Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 public:
     /// See Cpl::TShell::Command

--- a/src/Cpl/TShell/Cmd/FreeRTOS/Threads.cpp
+++ b/src/Cpl/TShell/Cmd/FreeRTOS/Threads.cpp
@@ -20,8 +20,9 @@ static const char* state2text_( eTaskState state );
 
 
 ///////////////////////////
-Threads::Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept
-    :Cpl::TShell::Cmd::Threads( commandList )
+Threads::Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+                  Security::Permission_T                     minPermLevel ) noexcept
+    :Cpl::TShell::Cmd::Threads( commandList, minPermLevel )
 {
 }
 

--- a/src/Cpl/TShell/Cmd/FreeRTOS/Threads.h
+++ b/src/Cpl/TShell/Cmd/FreeRTOS/Threads.h
@@ -33,7 +33,8 @@ class Threads : public Cpl::TShell::Cmd::Threads
 {
 public:
 	/// Constructor
-	Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept;
+	Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+			 Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 
 protected:

--- a/src/Cpl/TShell/Cmd/Help.cpp
+++ b/src/Cpl/TShell/Cmd/Help.cpp
@@ -22,8 +22,9 @@ static void outputLongText_( Cpl::TShell::Context_& context, bool& io, const cha
 
 
 ///////////////////////////
-Help::Help( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept
-	:Command( commandList, CPLTSHELLCMD_CMD_HELP_ )
+Help::Help( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+			Security::Permission_T                     minPermLevel ) noexcept
+	:Command( commandList, verb, minPermLevel )
 {
 }
 

--- a/src/Cpl/TShell/Cmd/Help.h
+++ b/src/Cpl/TShell/Cmd/Help.h
@@ -16,23 +16,6 @@
 #include "Cpl/TShell/Cmd/Command.h"
 
 
-/** Command
-                                    "         1         2         3         4         5         6         7         8"
-                                    "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-*/
-#define CPLTSHELLCMD_CMD_HELP_	    "help"
-/// Usage
-#define CPLTSHELLCMD_USAGE_HELP_    "help [* | <cmd>]"
-
-/// Detailed Help text
-#ifndef CPLTSHELLCMD_DETAIL_HELP_
-#define CPLTSHELLCMD_DETAIL_HELP_   "  Displays list of all supported commands and optionally their detailed help. If\n" \
-                                    "  the second argument is command, then the detailed help for that command will\n"   \
-                                    "  be displayed."
-
-#endif // ifndef allows detailed help to be compacted down to a single character if FLASH/code space is an issue
-
-
 ///
 namespace Cpl {
 ///
@@ -47,16 +30,33 @@ namespace Cmd {
 class Help : public Command
 {
 public:
+    /// The command verb/identifier
+    static constexpr const char* verb = "help";
+
+    /// The command usage string
+    static constexpr const char* usage = "help [* | <cmd>]";
+
+    /** The command detailed help string (recommended that lines do not exceed 80 chars)
+                                                          1         2         3         4         5         6         7         8
+                                                 12345678901234567890123456789012345678901234567890123456789012345678901234567890
+     */
+    static constexpr const char* detailedHelp = "  Displays list of all supported commands and optionally their detailed help. If\n" 
+                                                "  the second argument is command, then the detailed help for that command will\n"   
+                                                "  be displayed.";
+
+
+public:
     /// See Cpl::TShell::Command
-    const char* getUsage() const noexcept { return CPLTSHELLCMD_USAGE_HELP_; }
+    const char* getUsage() const noexcept { return usage; }
 
     /// See Cpl::TShell::Command
-    const char* getHelp() const noexcept { return CPLTSHELLCMD_DETAIL_HELP_; }
+    const char* getHelp() const noexcept { return detailedHelp; }
 
 
 public:
     /// Constructor
-    Help( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept;
+    Help( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+          Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 
 public:

--- a/src/Cpl/TShell/Cmd/TPrint.cpp
+++ b/src/Cpl/TShell/Cmd/TPrint.cpp
@@ -21,8 +21,9 @@ using namespace Cpl::TShell;
 
 
 ///////////////////////////
-TPrint::TPrint( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept
-	:Command( commandList, CPLTSHELLCMD_CMD_TPRINT_ )
+TPrint::TPrint( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+				Security::Permission_T                     minPermLevel ) noexcept
+	:Command( commandList, verb, minPermLevel )
 {
 }
 

--- a/src/Cpl/TShell/Cmd/TPrint.h
+++ b/src/Cpl/TShell/Cmd/TPrint.h
@@ -47,16 +47,31 @@ namespace Cmd {
 class TPrint : public Command
 {
 public:
+    /// The command verb/identifier
+    static constexpr const char* verb = "tprint";
+
+    /// The command usage string
+    static constexpr const char* usage = R"(tprint ["<text>"])";
+
+    /** The command detailed help string (recommended that lines do not exceed 80 chars)
+                                                          1         2         3         4         5         6         7         8
+                                                 12345678901234567890123456789012345678901234567890123456789012345678901234567890
+     */
+    static constexpr const char* detailedHelp = "  Outputs the optionally specified text with the current elapsed time is\n" \
+                                                "  prepended to the text.";
+
+public:
 	/// See Cpl::TShell::Command
-	const char* getUsage() const noexcept { return CPLTSHELLCMD_USAGE_TPRINT_; }
+	const char* getUsage() const noexcept { return usage; }
 
 	/// See Cpl::TShell::Command
-	const char* getHelp() const noexcept { return CPLTSHELLCMD_DETAIL_TPRINT_; }
+	const char* getHelp() const noexcept { return detailedHelp; }
 
 
 public:
 	/// Constructor
-	TPrint( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept;
+	TPrint( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+            Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 
 public:

--- a/src/Cpl/TShell/Cmd/Threads.cpp
+++ b/src/Cpl/TShell/Cmd/Threads.cpp
@@ -20,8 +20,9 @@
 using namespace Cpl::TShell::Cmd;
 
 ///////////////////////////
-Threads::Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept
-	:Command( commandList, CPLTSHELLCMD_CMD_THREADS_ )
+Threads::Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+				  Security::Permission_T                     minPermLevel ) noexcept
+	:Command( commandList, verb, minPermLevel )
 	, m_contextPtr( 0 )
 	, m_count( 0 )
 	, m_io( true )

--- a/src/Cpl/TShell/Cmd/Threads.h
+++ b/src/Cpl/TShell/Cmd/Threads.h
@@ -19,23 +19,6 @@
 
 
 
-/** Command
-										"         1         2         3         4         5         6         7         8"
-										"12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-*/
-#define CPLTSHELLCMD_CMD_THREADS_	    "threads"
-/// Usage
-#define CPLTSHELLCMD_USAGE_THREADS_     "threads"
-
-/// Detailed Help text
-#ifndef CPLTSHELLCMD_DETAIL_THREADS_
-#define CPLTSHELLCMD_DETAIL_THREADS_    "  Displays the list of threads."
-
-
-#endif // ifndef allows detailed help to be compacted down to a single character if FLASH/code space is an issue
-
-
-
 ///
 namespace Cpl {
 ///
@@ -50,11 +33,24 @@ namespace Cmd {
 class Threads : public Command, public Cpl::System::Thread::Traverser
 {
 public:
+	/// The command verb/identifier
+	static constexpr const char* verb = "threads";
+
+	/// The command usage string
+	static constexpr const char* usage = "threads";
+
+	/** The command detailed help string (recommended that lines do not exceed 80 chars)
+														  1         2         3         4         5         6         7         8
+												 12345678901234567890123456789012345678901234567890123456789012345678901234567890
+	 */
+	static constexpr const char* detailedHelp = "  Displays the list of threads.";
+
+public:
 	/// See Cpl::TShell::Command
-	const char* getUsage() const noexcept { return CPLTSHELLCMD_USAGE_THREADS_; }
+	const char* getUsage() const noexcept { return usage; }
 
 	/// See Cpl::TShell::Command
-	const char* getHelp() const noexcept { return CPLTSHELLCMD_DETAIL_THREADS_; }
+	const char* getHelp() const noexcept { return detailedHelp; }
 
 
 protected:
@@ -70,7 +66,8 @@ protected:
 
 public:
 	/// Constructor
-	Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept;
+	Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+			 Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 public:
 	/// See Cpl::TShell::Command

--- a/src/Cpl/TShell/Cmd/Tick.cpp
+++ b/src/Cpl/TShell/Cmd/Tick.cpp
@@ -22,8 +22,9 @@
 using namespace Cpl::TShell::Cmd;
 
 ///////////////////////////
-Tick::Tick( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept
-    :Command( commandList, CPLTSHELLCMD_CMD_TICK_ )
+Tick::Tick( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+            Security::Permission_T                     minPermLevel ) noexcept
+    :Command( commandList, verb, minPermLevel )
 {
 }
 

--- a/src/Cpl/TShell/Cmd/Tick.h
+++ b/src/Cpl/TShell/Cmd/Tick.h
@@ -15,22 +15,6 @@
 #include "colony_config.h"
 #include "Cpl/TShell/Cmd/Command.h"
 
-/** Command
-                                    "         1         2         3         4         5         6         7         8"
-                                    "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-*/
-#define CPLTSHELLCMD_CMD_TICK_		"tick"
-/// Usage
-#define CPLTSHELLCMD_USAGE_TICK_    "tick [+nn|@mm]"
-
-/// Detailed Help text
-#ifndef CPLTSHELLCMD_DETAIL_TICK_
-#define CPLTSHELLCMD_DETAIL_TICK_   "  Advances the simulated time by nn number of milliseconds and/or advances time\n" \
-                                    "  to an absolute time at mm milliseconds.  When no arguments are use the current\n" \
-                                    "  simulated and real time is displayed."
-
-#endif // ifndef allows detailed help to be compacted down to a single character if FLASH/code space is an issue
-
 
 ///
 namespace Cpl {
@@ -44,17 +28,34 @@ namespace Cmd {
  */
 class Tick : public Command
 {
+public:
+    /// The command verb/identifier
+    static constexpr const char* verb = "tick";
+
+    /// The command usage string
+    static constexpr const char* usage = "tick [+nn|@mm]";
+
+    /** The command detailed help string (recommended that lines do not exceed 80 chars)
+                                                          1         2         3         4         5         6         7         8
+                                                 12345678901234567890123456789012345678901234567890123456789012345678901234567890
+     */
+    static constexpr const char* detailedHelp = "  Advances the simulated time by nn number of milliseconds and/or advances time\n" 
+                                                "  to an absolute time at mm milliseconds.  When no arguments are use the current\n"
+                                                "  simulated and real time is displayed.";
+
+
 protected:
     /// See Cpl::TShell::Command
-    const char* getUsage() const noexcept { return CPLTSHELLCMD_USAGE_TICK_; }
+    const char* getUsage() const noexcept { return usage; }
 
     /// See Cpl::TShell::Command
-    const char* getHelp() const noexcept { return CPLTSHELLCMD_DETAIL_TICK_; }
+    const char* getHelp() const noexcept { return detailedHelp; }
 
 
 public:
     /// Constructor
-    Tick( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept;
+    Tick( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+          Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 public:
     /// See Cpl::TShell::Command

--- a/src/Cpl/TShell/Cmd/Trace.cpp
+++ b/src/Cpl/TShell/Cmd/Trace.cpp
@@ -29,8 +29,9 @@ static void dummy_( const char* f1, const char* f2, const char* f3, const char* 
 
 
 ///////////////////////////
-Trace::Trace( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept
-	:Command( commandList, CPLTSHELLCMD_CMD_TRACE_ )
+Trace::Trace( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+			  Security::Permission_T                     minPermLevel ) noexcept
+	:Command( commandList, verb, minPermLevel )
 {
 }
 

--- a/src/Cpl/TShell/Cmd/Trace.h
+++ b/src/Cpl/TShell/Cmd/Trace.h
@@ -16,28 +16,6 @@
 #include "Cpl/TShell/Cmd/Command.h"
 
 
-/** Command
-									"         1         2         3         4         5         6         7         8"
-									"12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-*/
-#define CPLTSHELLCMD_CMD_TRACE_		"trace"
-/// Usage
-#define CPLTSHELLCMD_USAGE_TRACE_	"trace [on|off]\n" \
-                                    "trace section (on|off) <sect1> [<sect2>]...\n" \
-                                    "trace threadfilters [<threadname1> [<threadname2>]]...\n" \
-                                    "trace level (none|brief|info|verbose|max)\n" \
-                                    "trace here|revert"
-
-/// Detailed Help text
-#ifndef CPLTSHELLCMD_DETAIL_TRACE_
-#define CPLTSHELLCMD_DETAIL_TRACE_  "  Enables/Disables the Cpl::System::Trace engine and manages the section',\n" \
-                                    "  information level, and thread filter options.  See the Cpl::System::Trace\n" \
-                                    "  interface for details on how the trace engine works."
-
-#endif // ifndef allows detailed help to be compacted down to a single character if FLASH/code space is an issue
-
-
-
 ///
 namespace Cpl {
 ///
@@ -52,16 +30,36 @@ namespace Cmd {
 class Trace : public Command
 {
 public:
+    /// The command verb/identifier
+    static constexpr const char* verb = "trace";
+
+    /// The command usage string
+    static constexpr const char* usage = "trace[on | off]\n"
+                                         "trace section( on | off ) < sect1 > [<sect2>]...\n"
+                                         "trace threadfilters[<threadname1>[<threadname2>]]...\n"
+                                         "trace level( none | brief | info | verbose | max )\n"
+                                         "trace here | revert";
+
+    /** The command detailed help string (recommended that lines do not exceed 80 chars)
+                                                          1         2         3         4         5         6         7         8
+                                                 12345678901234567890123456789012345678901234567890123456789012345678901234567890
+     */
+    static constexpr const char* detailedHelp = "  Enables/Disables the Cpl::System::Trace engine and manages the section',\n" \
+                                                "  information level, and thread filter options.  See the Cpl::System::Trace\n" \
+                                                "  interface for details on how the trace engine works.";
+
+public:
 	/// See Cpl::TShell::Command
-	const char* getUsage() const noexcept { return CPLTSHELLCMD_USAGE_TRACE_; }
+	const char* getUsage() const noexcept { return usage; }
 
 	/// See Cpl::TShell::Command
-	const char* getHelp() const noexcept { return CPLTSHELLCMD_DETAIL_TRACE_; }
+	const char* getHelp() const noexcept { return detailedHelp; }
 
 
 public:
 	/// Constructor
-	Trace( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept;
+	Trace( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+           Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 public:
 	/// See Cpl::TShell::Command

--- a/src/Cpl/TShell/Cmd/User.cpp
+++ b/src/Cpl/TShell/Cmd/User.cpp
@@ -19,7 +19,7 @@ using namespace Cpl::TShell::Cmd;
 
 ///////////////////////////
 User::User( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Cpl::TShell::Security& validator ) noexcept
-    : Command( commandList, CPLTSHELLCMD_CMD_USER_, Cpl::TShell::Security::ePUBLIC ) // ALWAYS a public command
+    : Command( commandList, verb, Cpl::TShell::Security::ePUBLIC ) // ALWAYS a public command
     , m_validator( validator )
 {
 }

--- a/src/Cpl/TShell/Cmd/User.h
+++ b/src/Cpl/TShell/Cmd/User.h
@@ -16,22 +16,6 @@
 #include "Cpl/TShell/Cmd/Command.h"
 
 
-/** Command
-                                    "         1         2         3         4         5         6         7         8"
-                                    "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-*/
-#define CPLTSHELLCMD_CMD_USER_	    "user"
-/// Usage
-#define CPLTSHELLCMD_USAGE_USER_    "user login <username> <password>\n" \
-                                    "user logout"
-
-/// Detailed Help text
-#ifndef CPLTSHELLCMD_DETAIL_USER_
-#define CPLTSHELLCMD_DETAIL_USER_   "  Used to login/logout a user"
-
-#endif // ifndef allows detailed help to be compacted down to a single character if FLASH/code space is an issue
-
-
 ///
 namespace Cpl {
 ///
@@ -46,11 +30,28 @@ namespace Cmd {
 class User : public Command
 {
 public:
+    /// The command verb/identifier
+    static constexpr const char* verb = "user";
+
+    /// The command usage string
+    static constexpr const char* usage = "user login <username> <password>\n" 
+                                         "user logout";
+
+    /** The command detailed help string (recommended that lines do not exceed 80 chars)
+                                                          1         2         3         4         5         6         7         8
+                                                 12345678901234567890123456789012345678901234567890123456789012345678901234567890
+     */
+    static constexpr const char* detailedHelp = "  Enables/Disables the Cpl::System::Trace engine and manages the section',\n" 
+                                                "  information level, and thread filter options.  See the Cpl::System::Trace\n" 
+                                                "  interface for details on how the trace engine works.";
+
+
+public:
     /// See Cpl::TShell::Command
-    const char* getUsage() const noexcept { return CPLTSHELLCMD_USAGE_USER_; }
+    const char* getUsage() const noexcept { return usage; }
 
     /// See Cpl::TShell::Command
-    const char* getHelp() const noexcept { return CPLTSHELLCMD_DETAIL_USER_; }
+    const char* getHelp() const noexcept { return detailedHelp; }
 
 
 public:

--- a/src/Cpl/TShell/Cmd/Win32/Threads.cpp
+++ b/src/Cpl/TShell/Cmd/Win32/Threads.cpp
@@ -19,8 +19,9 @@ using namespace Cpl::TShell::Cmd::Win32;
 
 
 ///////////////////////////
-Threads::Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept
-	:Cpl::TShell::Cmd::Threads( commandList )
+Threads::Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+				  Security::Permission_T                     minPermLevel ) noexcept
+	:Cpl::TShell::Cmd::Threads( commandList, minPermLevel )
 {
 }
 

--- a/src/Cpl/TShell/Cmd/Win32/Threads.h
+++ b/src/Cpl/TShell/Cmd/Win32/Threads.h
@@ -33,7 +33,8 @@ class Threads : public Cpl::TShell::Cmd::Threads
 {
 public:
 	/// Constructor
-	Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList ) noexcept;
+	Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+			 Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 
 protected:

--- a/src/Cpl/TShell/Command.h
+++ b/src/Cpl/TShell/Command.h
@@ -62,7 +62,7 @@ public:
 
 	/** This method returns the command's detailed help string.  Detailed
 		help is optional.  If the command does not support detailed help,
-		then 0 is returned.
+		then nullptr is returned.
 	 */
 	virtual const char* getHelp() const noexcept = 0;
 

--- a/src/Cpl/TShell/Maker.cpp
+++ b/src/Cpl/TShell/Maker.cpp
@@ -19,7 +19,7 @@ using namespace Cpl::TShell;
 Maker::Maker( Cpl::Container::Map<Command>& cmdlist, Cpl::System::Mutex& lock )
 	: m_framer( 0, '\0', '\n', '\0', false )
 	, m_deframer( 0, ' ' )
-	, m_processor( cmdlist, m_deframer, m_framer, lock, 0, 0 )
+	, m_processor( cmdlist, m_deframer, m_framer, lock )
 {
 }
 

--- a/src/Cpl/TShell/PolledMaker.cpp
+++ b/src/Cpl/TShell/PolledMaker.cpp
@@ -19,7 +19,7 @@ using namespace Cpl::TShell;
 PolledMaker::PolledMaker( Cpl::Container::Map<Command>& cmdlist, Cpl::System::Mutex& lock )
 	: m_framer( 0, '\0', '\n', '\0', false )
 	, m_deframer( 0, ' ', false )
-	, m_processor( cmdlist, m_deframer, m_framer, lock, 0, 0 )
+	, m_processor( cmdlist, m_deframer, m_framer, lock )
 {
 }
 

--- a/src/Cpl/TShell/Processor.h
+++ b/src/Cpl/TShell/Processor.h
@@ -22,14 +22,14 @@
 
 
 /** This symbol defines the size, in bytes, of the maximum allowed input
-	string/command.
+    string/command.
  */
 #ifndef OPTION_CPL_TSHELL_PROCESSOR_INPUT_SIZE
 #define OPTION_CPL_TSHELL_PROCESSOR_INPUT_SIZE              128
 #endif
 
  /** This symbol defines the size, in bytes, of the maximum allowed unframed
-	 output string/command.
+     output string/command.
   */
 #ifndef OPTION_CPL_TSHELL_PROCESSOR_OUTPUT_SIZE
 #define OPTION_CPL_TSHELL_PROCESSOR_OUTPUT_SIZE             256
@@ -59,217 +59,217 @@ namespace Cpl {
 namespace TShell {
 
 /** This concrete class provides the implementation of Command Processor for
-	a TShell engine.
+    a TShell engine.
 
-	The implementation assumes a single threaded model, i.e. the Command
-	Processor and all of its  commands run in a single thread.  It is
-	APPLICATION's responsibility to provide any desired multi-threaded
-	support. There are two caveats to the single-threaded model:
+    The implementation assumes a single threaded model, i.e. the Command
+    Processor and all of its  commands run in a single thread.  It is
+    APPLICATION's responsibility to provide any desired multi-threaded
+    support. There are two caveats to the single-threaded model:
 
-		o The output of the commands are mutex protected.  This allows the
-		  Output stream to be 'shared' with other sub-systems and/or
-		  threads (e.g. the shell shares the same Output stream as the
-		  Cpl::System::Trace logging output).
+        o The output of the commands are mutex protected.  This allows the
+          Output stream to be 'shared' with other sub-systems and/or
+          threads (e.g. the shell shares the same Output stream as the
+          Cpl::System::Trace logging output).
 
-		o The stop() method can be called safely from other threads.
+        o The stop() method can be called safely from other threads.
 
 
-	Commands have the following syntax:
+    Commands have the following syntax:
 
-		o A command starts with a printable ASCII character and ends with
-		  a newline.
+        o A command starts with a printable ASCII character and ends with
+          a newline.
 
-		o Non-printable ASCII characters are not allowed.
+        o Non-printable ASCII characters are not allowed.
 
-		o Any line that starts with a '#' is treated as comment line and
-		  is ignored.
+        o Any line that starts with a '#' is treated as comment line and
+          is ignored.
 
-		o Format of a command is: verb [arg]*  where the verb and arguments
-		  are separated by spaces.  Arguments can contain spaces character
-		  by enclosing the argument with double quote characters.  A double
-		  quote character can be embedded inside a quoted string by preceding
-		  it the double quote character with the escape character.  The escape
-		  character can be embedded by escaping the escape character.
+        o Format of a command is: verb [arg]*  where the verb and arguments
+          are separated by spaces.  Arguments can contain spaces character
+          by enclosing the argument with double quote characters.  A double
+          quote character can be embedded inside a quoted string by preceding
+          it the double quote character with the escape character.  The escape
+          character can be embedded by escaping the escape character.
 
-	The USE_CPL_TSHELL_PROCESSOR_SILENT_WHEN_PUBLIC switch is use
-	to alter the TShell's output behavior - to not 'say anything'
-	until a user has successfully been authenticated (using the 'User'
-	command
+    The USE_CPL_TSHELL_PROCESSOR_SILENT_WHEN_PUBLIC switch is use
+    to alter the TShell's output behavior - to not 'say anything'
+    until a user has successfully been authenticated (using the 'User'
+    command
 
-	HOW TO Enable Security:
+    HOW TO Enable Security:
 
-		- Set OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL to something
-		  other than ePUBLIC.  This will be the permission for all legacy (i.e.
-		  not Security aware) TShell commands
+        - Set OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL to something
+          other than ePUBLIC.  This will be the permission for all legacy (i.e.
+          not Security aware) TShell commands
 
-		- Recommend turning on the switch: USE_CPL_TSHELL_PROCESSOR_SILENT_WHEN_PUBLIC
+        - Recommend turning on the switch: USE_CPL_TSHELL_PROCESSOR_SILENT_WHEN_PUBLIC
 
-		- Include the Cpl::TShell::Cmd::User command and provide an 
-		  implementation of the Cpl::TShell::Security interface (that is passed 
-		  to the command's constructor).
+        - Include the Cpl::TShell::Cmd::User command and provide an 
+          implementation of the Cpl::TShell::Security interface (that is passed 
+          to the command's constructor).
 
-		- Optionally include new security aware commands
+        - Optionally include new security aware commands
  */
 class Processor : public Context_
 {
 public:
-	/** Constructor.
+    /** Constructor.
 
-		@param commands					Set of supported commands
-		@param deframer					Frame decoder used to identify individual command
-										strings within the raw Input stream
-		@param framer					Frame encoder used to encapsulate the output of
-										command in the Output stream.
-		@param outputLock				Mutex to be used for ensuring the atomic output
-										of the commands.
-		@param commentChar				The comment character used to indicate that the
-										input string is a comment and should not be
-										executed.
-		@param argEscape				Escape character to be used when escaping double
-										quote characters inside a quoted argument.
-		@param argDelimiter				The delimiter character used to separate the
-										command verb and arguments.
-		@param argQuote					The quote character used to 'double quote' a
-										argument string.
-		@param argTerminator			The command terminator character.
-		@param initialPermissionLevel   The initial minimum permission level that a user needs to issue command(s)
-	 */
-	Processor( Cpl::Container::Map<Command>&     commands,
-			   Cpl::Text::Frame::StreamDecoder&  deframer,
-			   Cpl::Text::Frame::StreamEncoder&  framer,
-			   Cpl::System::Mutex&               outputLock,
-			   char                              commentChar='#',
-			   char                              argEscape='`',
-			   char                              argDelimiter=' ',
-			   char                              argQuote='"',
-			   char                              argTerminator='\n',
-			   Security::Permission_T            initialPermissionLevel = Security::ePUBLIC
-	);
+        @param commands					Set of supported commands
+        @param deframer					Frame decoder used to identify individual command
+                                        strings within the raw Input stream
+        @param framer					Frame encoder used to encapsulate the output of
+                                        command in the Output stream.
+        @param outputLock				Mutex to be used for ensuring the atomic output
+                                        of the commands.
+        @param commentChar				The comment character used to indicate that the
+                                        input string is a comment and should not be
+                                        executed.
+        @param argEscape				Escape character to be used when escaping double
+                                        quote characters inside a quoted argument.
+        @param argDelimiter				The delimiter character used to separate the
+                                        command verb and arguments.
+        @param argQuote					The quote character used to 'double quote' a
+                                        argument string.
+        @param argTerminator			The command terminator character.
+        @param initialPermissionLevel   The initial minimum permission level that a user needs to issue command(s)
+     */
+    Processor( Cpl::Container::Map<Command>&     commands,
+               Cpl::Text::Frame::StreamDecoder&  deframer,
+               Cpl::Text::Frame::StreamEncoder&  framer,
+               Cpl::System::Mutex&               outputLock,
+               char                              commentChar='#',
+               char                              argEscape='`',
+               char                              argDelimiter=' ',
+               char                              argQuote='"',
+               char                              argTerminator='\n',
+               Security::Permission_T            initialPermissionLevel = Security::ePUBLIC
+    );
 
-
-public:
-	/// See Cpl::TShell::ProcessorApi
-	bool start( Cpl::Io::Input& infd, Cpl::Io::Output& outfd, bool blocking=true ) noexcept;
-
-	/// See Cpl::TShell::ProcessorApi
-	int poll() noexcept;
-
-	/// See Cpl::TShell::ProcessorApi
-	void requestStop() noexcept;
-
-	/// See Cpl::TShell::ProcessorApi
-	char getEscapeChar() noexcept;
-
-	/// See Cpl::TShell::ProcessorApi
-	char getDelimiterChar() noexcept;
-
-	/// See Cpl::TShell::ProcessorApi
-	char getQuoteChar() noexcept;
-
-	/// See Cpl::TShell::ProcessorApi
-	char getTerminatorChar() noexcept;
 
 public:
-	/// See Cpl::TShell::Context_
-	Cpl::Container::Map<Command>& getCommands() noexcept;
+    /// See Cpl::TShell::ProcessorApi
+    bool start( Cpl::Io::Input& infd, Cpl::Io::Output& outfd, bool blocking=true ) noexcept;
 
-	/// See Cpl::TShell::Context_
-	bool writeFrame( const char* text ) noexcept;
+    /// See Cpl::TShell::ProcessorApi
+    int poll() noexcept;
 
-	/// See Cpl::TShell::Context_
-	bool writeFrame( const char* text, size_t maxBytes ) noexcept;
+    /// See Cpl::TShell::ProcessorApi
+    void requestStop() noexcept;
 
-	/// See Cpl::TShell::Context_
-	Cpl::Text::String& getOutputBuffer() noexcept;
+    /// See Cpl::TShell::ProcessorApi
+    char getEscapeChar() noexcept;
 
-	/// See Cpl::TShell::Context_
-	Cpl::Text::String& getTokenBuffer() noexcept;
+    /// See Cpl::TShell::ProcessorApi
+    char getDelimiterChar() noexcept;
 
-	/// See Cpl::TShell::Context_
-	Cpl::Text::String& getTokenBuffer2() noexcept;
+    /// See Cpl::TShell::ProcessorApi
+    char getQuoteChar() noexcept;
 
-	/// See Cpl::TShell::Context_
-	bool oobRead( void* buffer, int numBytes, int& bytesRead ) noexcept;
+    /// See Cpl::TShell::ProcessorApi
+    char getTerminatorChar() noexcept;
 
-	/// See Cpl::TShell::Context_
-	Security::Permission_T getUserPermissionLevel() const noexcept;
+public:
+    /// See Cpl::TShell::Context_
+    Cpl::Container::Map<Command>& getCommands() noexcept;
 
-	/// See Cpl::TShell::Context_
-	Security::Permission_T setUserPermissionLevel( Security::Permission_T newPermissionLevel ) noexcept;
+    /// See Cpl::TShell::Context_
+    bool writeFrame( const char* text ) noexcept;
+
+    /// See Cpl::TShell::Context_
+    bool writeFrame( const char* text, size_t maxBytes ) noexcept;
+
+    /// See Cpl::TShell::Context_
+    Cpl::Text::String& getOutputBuffer() noexcept;
+
+    /// See Cpl::TShell::Context_
+    Cpl::Text::String& getTokenBuffer() noexcept;
+
+    /// See Cpl::TShell::Context_
+    Cpl::Text::String& getTokenBuffer2() noexcept;
+
+    /// See Cpl::TShell::Context_
+    bool oobRead( void* buffer, int numBytes, int& bytesRead ) noexcept;
+
+    /// See Cpl::TShell::Context_
+    Security::Permission_T getUserPermissionLevel() const noexcept;
+
+    /// See Cpl::TShell::Context_
+    Security::Permission_T setUserPermissionLevel( Security::Permission_T newPermissionLevel ) noexcept;
 
 protected:
-	/** Helper method that attempts to execute the content of the de-framed/decoded
-	    'inputString'.  The method returns the result code of the execute
-   		command.  If 'inputString' is not a valid command, then the appropriate
-		error/result code is returned.
-	 */
-	virtual Command::Result_T executeCommand( char* deframedInput, Cpl::Io::Output& outfd ) noexcept;
+    /** Helper method that attempts to execute the content of the de-framed/decoded
+        'inputString'.  The method returns the result code of the execute
+        command.  If 'inputString' is not a valid command, then the appropriate
+        error/result code is returned.
+     */
+    virtual Command::Result_T executeCommand( char* deframedInput, Cpl::Io::Output& outfd ) noexcept;
 
-	/// Helper method
-	bool outputCommandError( Command::Result_T result, const char* deframedInput ) noexcept;
+    /// Helper method
+    bool outputCommandError( Command::Result_T result, const char* deframedInput ) noexcept;
 
-	/** Helper method that performs a 'single' read cycle of the input stream.
-		Returns 0 if successful. Returns 1 if exiting. Returns -1 on error
-	 */
-	int getAndProcessFrame( Cpl::Io::Output& outfd ) noexcept;
+    /** Helper method that performs a 'single' read cycle of the input stream.
+        Returns 0 if successful. Returns 1 if exiting. Returns -1 on error
+     */
+    int getAndProcessFrame( Cpl::Io::Output& outfd ) noexcept;
 
-	/** Helper method that executes the decoder, i.e. logic to parse the incoming
-	    text.  Returns 1 if a full/valid frame was found. Returns 0 if input frame
-		is incomplete. Return -1 if an error occurred.
-	 */
-	virtual int readInput( size_t& frameSize ) noexcept;
+    /** Helper method that executes the decoder, i.e. logic to parse the incoming
+        text.  Returns 1 if a full/valid frame was found. Returns 0 if input frame
+        is incomplete. Return -1 if an error occurred.
+     */
+    virtual int readInput( size_t& frameSize ) noexcept;
 
 protected:
-	/// Command list
-	Cpl::Container::Map<Command>&       m_commands;
+    /// Command list
+    Cpl::Container::Map<Command>&       m_commands;
 
-	/// Raw input de-framer
-	Cpl::Text::Frame::StreamDecoder&    m_deframer;
+    /// Raw input de-framer
+    Cpl::Text::Frame::StreamDecoder&    m_deframer;
 
-	/// Output framer handle
-	Cpl::Text::Frame::StreamEncoder&    m_framer;
+    /// Output framer handle
+    Cpl::Text::Frame::StreamEncoder&    m_framer;
 
-	/// Output lock
-	Cpl::System::Mutex&                 m_outLock;
+    /// Output lock
+    Cpl::System::Mutex&                 m_outLock;
 
-	/// User's permission level	
-	Security::Permission_T				m_userPermLevel;
+    /// User's permission level	
+    Security::Permission_T				m_userPermLevel;
 
-	/// Comment character
-	char                                m_comment;
+    /// Comment character
+    char                                m_comment;
 
-	/// Argument Escape character
-	char                                m_esc;
+    /// Argument Escape character
+    char                                m_esc;
 
-	/// Argument delimiter
-	char                                m_del;
+    /// Argument delimiter
+    char                                m_del;
 
-	/// Argument quote character
-	char                                m_quote;
+    /// Argument quote character
+    char                                m_quote;
 
-	/// Argument terminator character
-	char                                m_term;
+    /// Argument terminator character
+    char                                m_term;
 
-	/// Set to true when 'command prompt' should be outputted
-	bool								m_writeCommandPrompt;
+    /// Set to true when 'command prompt' should be outputted
+    bool								m_writeCommandPrompt;
 
-	/// Current frame size
-	size_t								m_frameSize;
+    /// Current frame size
+    size_t								m_frameSize;
 
-	/// My run state
-	bool                                m_running;
+    /// My run state
+    bool                                m_running;
 
-	/// Input Frame buffer
-	char                                m_inputBuffer[OPTION_CPL_TSHELL_PROCESSOR_INPUT_SIZE + 1];
+    /// Input Frame buffer
+    char                                m_inputBuffer[OPTION_CPL_TSHELL_PROCESSOR_INPUT_SIZE + 1];
 
-	/// Buffer that is used to construct output messages
-	Cpl::Text::FString<OPTION_CPL_TSHELL_PROCESSOR_OUTPUT_SIZE>  m_outputBuffer;
+    /// Buffer that is used to construct output messages
+    Cpl::Text::FString<OPTION_CPL_TSHELL_PROCESSOR_OUTPUT_SIZE>  m_outputBuffer;
 
-	/// Shared token work buffer
-	Cpl::Text::FString<OPTION_CPL_TSHELL_PROCESSOR_INPUT_SIZE>   m_tokenBuffer;
+    /// Shared token work buffer
+    Cpl::Text::FString<OPTION_CPL_TSHELL_PROCESSOR_INPUT_SIZE>   m_tokenBuffer;
 
-	/// Shared token work buffer
-	Cpl::Text::FString<OPTION_CPL_TSHELL_PROCESSOR_INPUT_SIZE>   m_tokenBuffer2;
+    /// Shared token work buffer
+    Cpl::Text::FString<OPTION_CPL_TSHELL_PROCESSOR_INPUT_SIZE>   m_tokenBuffer2;
 };
 
 


### PR DESCRIPTION
- Fix bug where the quote/escape characters where not being set correctly for the TShell Maker objects. 
- Clean-up help strings 
- Make base TShell command security aware