### PR TITLE
Refactor TShell and MApp for smaller print and minor maintaince

### DIFF
--- a/pkg.info/package.json
+++ b/pkg.info/package.json
@@ -187,7 +187,7 @@
       "version": "5.0.0",
       "date": "Mon May  5 11:54:45 2025",
       "timestamp": 1746446085,
-      "changes": "\"Breaking Change:\\n- Refactor TShell and MApp for smaller memory footprint\\n\\nMaintenance:\\n- SList: prevent potential stack overflow\\n- Document necessary edits to the Little FS repo (when using the Microsoft compiler)\\n- Prevent fatal-error-infinite-loop when a unit test failure occurs\\n- Fix race condition on UART driver\\n\\n\""
+      "changes": "\"Breaking Change:\\n- Refactor TShell and MApp for smaller memory footprint\\n\\nMaintenance:\\n- SList: prevent potential stack overflow\\n- Document necessary edits to the Little FS repo (when using the Microsoft compiler)\\n- Prevent fatal-error-infinite-loop when a unit test failure occurs\\n- Fix race condition on UART driver\\n- Fix bug in the BitArray base class\""
     },
     "history": [
       {

--- a/pkg.info/package.json
+++ b/pkg.info/package.json
@@ -183,13 +183,20 @@
   },
   "publish": {
     "current": {
-      "comment": "Add support for Littlefs",
-      "version": "4.5.2",
-      "date": "Sat Jan 11 19:09:20 2025",
-      "timestamp": 1736622560,
-      "changes": null
+      "comment": "Refactor TShell and MApp - breaking change",
+      "version": "5.0.0",
+      "date": "Mon May  5 11:54:45 2025",
+      "timestamp": 1746446085,
+      "changes": "\"Breaking Change:\\n- Refactor TShell and MApp for smaller memory footprint\\n\\nMaintenance:\\n- SList: prevent potential stack overflow\\n- Document necessary edits to the Little FS repo (when using the Microsoft compiler)\\n- Prevent fatal-error-infinite-loop when a unit test failure occurs\\n- Fix race condition on UART driver\\n\\n\""
     },
     "history": [
+      {
+        "comment": "Add support for Littlefs",
+        "version": "4.5.2",
+        "date": "Sat Jan 11 19:09:20 2025",
+        "timestamp": 1736622560,
+        "changes": null
+      },
       {
         "comment": "Migrate to Catch2 v3.x test framework (now uses a static library instead of single header file)",
         "version": "4.5.1",

--- a/pkg.info/pkg-dirs.lst
+++ b/pkg.info/pkg-dirs.lst
@@ -268,7 +268,10 @@ tests/Cpl/Dm/_0test/realtime/windows/mingw_w64
 tests/Cpl/Dm/_0test/realtime/windows/vc12
 tests/Cpl/Io/File/Littlefs
 tests/Cpl/Io/File/Littlefs/TShell/_0test
+tests/Cpl/Io/File/Littlefs/TShell/_0test/linux
+tests/Cpl/Io/File/Littlefs/TShell/_0test/linux/gcc
 tests/Cpl/Io/File/Littlefs/TShell/_0test/windows
+tests/Cpl/Io/File/Littlefs/TShell/_0test/windows/mingw_w64
 tests/Cpl/Io/File/Littlefs/TShell/_0test/windows/vc12
 tests/Cpl/Io/File/Littlefs/_0test/multiplevolumes
 tests/Cpl/Io/File/Littlefs/_0test/multiplevolumes/linux

--- a/src/Cpl/Container/DictItem.h
+++ b/src/Cpl/Container/DictItem.h
@@ -23,7 +23,7 @@ namespace Container {
 
 
 /** This abstract class represents a item that can be contained in
-    Dictionary.  The Dictionary is an ordered map implemented as a hash table
+    Dictionary.  The Dictionary is an unordered map implemented as a hash table
     that can only contain item(s) with same key type. The client sub-class is
     required to implement the 'getKey() method.
 

--- a/src/Cpl/Container/Stack.h
+++ b/src/Cpl/Container/Stack.h
@@ -55,7 +55,7 @@ public:
     /** Adds an item to the top of the stack.  Returns true if successful;
         else false is returned (e.g. on stack overflow).
      */
-    bool push( const ITEM src ) noexcept;
+    bool push( const ITEM& src ) noexcept;
 
 
     /** Removes the top item of the stack.  If the stack is empty, 
@@ -140,7 +140,7 @@ inline void Stack<ITEM>::clearTheStack() noexcept
 
 
 template <class ITEM>
-inline bool Stack<ITEM>::push( const ITEM item ) noexcept
+inline bool Stack<ITEM>::push( const ITEM& item ) noexcept
 {
     if ( isFull() )
     {

--- a/src/Cpl/Dm/Mp/BitArray32.h
+++ b/src/Cpl/Dm/Mp/BitArray32.h
@@ -1,5 +1,5 @@
-#ifndef Cpl_Dm_Mp_BitArray16_h_
-#define Cpl_Dm_Mp_BitArray16_h_
+#ifndef Cpl_Dm_Mp_BitArray32_h_
+#define Cpl_Dm_Mp_BitArray32_h_
 /*-----------------------------------------------------------------------------
 * This file is part of the Colony.Core Project.  The Colony.Core Project is an
 * open source project with a BSD type of licensing agreement.  See the license
@@ -29,7 +29,7 @@ namespace Mp {
 
 /** This template class provides a concrete implementation for a Point who's
     data is a a bit array of N bits.  The underlying storage of the bit array is
-    16 bit unsigned integers.  A side effect of this storage
+    32 bit unsigned integers.  A side effect of this storage
     mechanism the bit ordering in the JSON 'val' string is dependent on the
     target platform's Endian architecture.
 
@@ -43,7 +43,7 @@ namespace Mp {
         Whether byte[0] is the MSB or LSB is dependent on the big/little Endian
         architecture of the target platform.
 
-        For example a 16bit Array (as binary hex: dataword[0]=0x30, dataword[1]=0x09)
+        For example a 16bit Array (as binary hex: dataword[0]=0x30, dataword[1]=0x09, dataword[2]=0x30, dataword[3]=0x09)
 
             val:"0011000000001001"
 
@@ -53,32 +53,32 @@ namespace Mp {
           documented otherwise.
 
  */
-class BitArray16 : public BitArray_<uint16_t, BitArray16>
+class BitArray32 : public BitArray_<uint32_t, BitArray32>
 {
 public:
         /** Constructor. Invalid MP.
      */
-    BitArray16( Cpl::Dm::ModelDatabase& myModelBase, const char* symbolicName )
-        : BitArray_<uint16_t, BitArray16>( myModelBase, symbolicName )
+    BitArray32( Cpl::Dm::ModelDatabase& myModelBase, const char* symbolicName )
+        : BitArray_<uint32_t, BitArray32>( myModelBase, symbolicName )
     {
     }
 
     /// Constructor. Valid MP.  Requires an initial value
-    BitArray16( Cpl::Dm::ModelDatabase& myModelBase, const char* symbolicName, uint16_t initialValue )
-        : BitArray_<uint16_t, BitArray16>( myModelBase, symbolicName, initialValue )
+    BitArray32( Cpl::Dm::ModelDatabase& myModelBase, const char* symbolicName, uint32_t initialValue )
+        : BitArray_<uint32_t, BitArray32>( myModelBase, symbolicName, initialValue )
     {
     }
 
 public:
     /// Type safe subscriber
-    typedef Cpl::Dm::Subscriber<BitArray16> Observer;
+    typedef Cpl::Dm::Subscriber<BitArray32> Observer;
 
 
 public:
     ///  See Cpl::Dm::ModelPoint.
     const char* getTypeAsText() const noexcept
     {
-        return "Cpl::Dm::Mp::BitArray16";
+        return "Cpl::Dm::Mp::BitArray32";
     }
 };
 

--- a/src/Cpl/Dm/Mp/Numeric.h
+++ b/src/Cpl/Dm/Mp/Numeric.h
@@ -1,15 +1,15 @@
 #ifndef Cpl_Dm_Mp_Numeric_h_
 #define Cpl_Dm_Mp_Numeric_h_
 /*-----------------------------------------------------------------------------
-* This file is part of the Colony.Core Project.  The Colony.Core Project is an
-* open source project with a BSD type of licensing agreement.  See the license
-* agreement (license.txt) in the top/ directory or on the Internet at
-* http://integerfox.com/colony.core/license.txt
-*
-* Copyright (c) 2014-2022  John T. Taylor
-*
-* Redistributions of the source code must retain the above copyright notice.
-*----------------------------------------------------------------------------*/
+ * This file is part of the Colony.Core Project.  The Colony.Core Project is an
+ * open source project with a BSD type of licensing agreement.  See the license
+ * agreement (license.txt) in the top/ directory or on the Internet at
+ * http://integerfox.com/colony.core/license.txt
+ *
+ * Copyright (c) 2014-2022  John T. Taylor
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
 /** @file */
 
 
@@ -25,22 +25,22 @@
 /// Hack to get around that NOT all compilers support the "%llx" notation for printf
 #if INTPTR_MAX == INT32_MAX
 /// print format max integer
-#define PRINTF_SIZET_FMT    "%lx"
+#define PRINTF_SIZET_FMT "%lx"
 /// type for max integer
-#define PRINTF_SIZET_TYPE   unsigned long
+#define PRINTF_SIZET_TYPE unsigned long
 
 #elif INTPTR_MAX == INT64_MAX
 /// print format max integer
-#define PRINTF_SIZET_FMT    "%llx"
+#define PRINTF_SIZET_FMT  "%llx"
 /// print format max integer
-#define PRINTF_SIZET_TYPE   unsigned long long
+#define PRINTF_SIZET_TYPE unsigned long long
 #else
 #error "Environment not 32 or 64-bit."
 #endif
 
 /// Endianess of a Bit array.  For little endian set to true; else set to false
 #ifndef OPTION_CPL_DM_MP_BITARRAY_IS_LITTLE_ENDIAN
-#define OPTION_CPL_DM_MP_BITARRAY_IS_LITTLE_ENDIAN        true
+#define OPTION_CPL_DM_MP_BITARRAY_IS_LITTLE_ENDIAN true
 #endif
 
 
@@ -59,23 +59,23 @@ namespace Mp {
         1) All methods in this class are NOT thread Safe unless explicitly
         documented otherwise.
  */
-template<class ELEMTYPE, class MPTYPE>
+template <class ELEMTYPE, class MPTYPE>
 class Numeric : public Cpl::Dm::ModelPointCommon_
 {
 protected:
     /// The element's value
-    ELEMTYPE    m_data;
+    ELEMTYPE m_data;
 
 protected:
     /// Constructor: Invalid MP
     Numeric( Cpl::Dm::ModelDatabase& myModelBase, const char* symbolicName )
-        :Cpl::Dm::ModelPointCommon_( myModelBase, symbolicName, &m_data, sizeof( m_data ), false )
+        : Cpl::Dm::ModelPointCommon_( myModelBase, symbolicName, &m_data, sizeof( m_data ), false )
     {
     }
 
     /// Constructor: Valid MP (requires initial value)
     Numeric( Cpl::Dm::ModelDatabase& myModelBase, const char* symbolicName, ELEMTYPE initialValue )
-        :Cpl::Dm::ModelPointCommon_( myModelBase, symbolicName, &m_data, sizeof( m_data ), true )
+        : Cpl::Dm::ModelPointCommon_( myModelBase, symbolicName, &m_data, sizeof( m_data ), true )
     {
         m_data = initialValue;
     }
@@ -136,14 +136,14 @@ public:
     }
 
 protected:
-    /// See Cpl::Dm::Point.  
+    /// See Cpl::Dm::Point.
     void setJSONVal( JsonDocument& doc ) noexcept
     {
         doc["val"] = m_data;
     }
 
 public:
-    /// See Cpl::Dm::Point.  
+    /// See Cpl::Dm::Point.
     bool fromJSON_( JsonVariant& src, Cpl::Dm::ModelPoint::LockRequest_T lockRequest, uint16_t& retSequenceNumber, Cpl::Text::String* errorMsg ) noexcept
     {
         if ( src.is<ELEMTYPE>() )
@@ -234,8 +234,8 @@ public:
 
 
 public:
-    /// Atomic operation to clear ONLY the bits as specified by the bit mask.  
-    inline uint16_t clearBitsByMask( uint16_t bitMask, Cpl::Dm::ModelPoint::LockRequest_T lockRequest = Cpl::Dm::ModelPoint::eNO_REQUEST ) noexcept
+    /// Atomic operation to clear ONLY the bits as specified by the bit mask.
+    inline uint16_t clearBitsByMask( WORDSIZE bitMask, Cpl::Dm::ModelPoint::LockRequest_T lockRequest = Cpl::Dm::ModelPoint::eNO_REQUEST ) noexcept
     {
         Cpl::Dm::ModelPointCommon_::m_modelDatabase.lock_();
         uint16_t result = Numeric<WORDSIZE, MPTYPE>::write( Numeric<WORDSIZE, MPTYPE>::m_data & ~( bitMask ), lockRequest );
@@ -244,7 +244,7 @@ public:
     }
 
     /// Atomic operation to set the bits specified by the bit mask
-    inline uint16_t setBitsByMask( uint16_t bitMask, Cpl::Dm::ModelPoint::LockRequest_T lockRequest = Cpl::Dm::ModelPoint::eNO_REQUEST ) noexcept
+    inline uint16_t setBitsByMask( WORDSIZE bitMask, Cpl::Dm::ModelPoint::LockRequest_T lockRequest = Cpl::Dm::ModelPoint::eNO_REQUEST ) noexcept
     {
         Cpl::Dm::ModelPointCommon_::m_modelDatabase.lock_();
         uint16_t result = Numeric<WORDSIZE, MPTYPE>::write( Numeric<WORDSIZE, MPTYPE>::m_data | bitMask, lockRequest );
@@ -253,7 +253,7 @@ public:
     }
 
     /// Atomic operation to flip/toggle ONLY the bits as specified the bit mask
-    inline uint16_t flipBitsByMask( uint16_t bitMask, Cpl::Dm::ModelPoint::LockRequest_T lockRequest = Cpl::Dm::ModelPoint::eNO_REQUEST ) noexcept
+    inline uint16_t flipBitsByMask( WORDSIZE bitMask, Cpl::Dm::ModelPoint::LockRequest_T lockRequest = Cpl::Dm::ModelPoint::eNO_REQUEST ) noexcept
     {
         Cpl::Dm::ModelPointCommon_::m_modelDatabase.lock_();
         uint16_t result = Numeric<WORDSIZE, MPTYPE>::write( Numeric<WORDSIZE, MPTYPE>::m_data ^ bitMask, lockRequest );
@@ -264,24 +264,24 @@ public:
 
 
 protected:
-    /// See Cpl::Dm::Point.  
+    /// See Cpl::Dm::Point.
     void setJSONVal( JsonDocument& doc ) noexcept
     {
         Cpl::Text::FString<64> tmp;
-        const void* dataPtr = &(Numeric<WORDSIZE, MPTYPE>::m_data);
+        const void*            dataPtr = &( Numeric<WORDSIZE, MPTYPE>::m_data );
         Cpl::Text::bufferToAsciiBinary( dataPtr, sizeof( Numeric<WORDSIZE, MPTYPE>::m_data ), tmp, false, OPTION_CPL_DM_MP_BITARRAY_IS_LITTLE_ENDIAN );
-        doc["val"] = (char*) tmp.getString();
+        doc["val"] = (char*)tmp.getString();
     }
 
 
 public:
-    /// See Cpl::Dm::Point.  
+    /// See Cpl::Dm::Point.
     bool fromJSON_( JsonVariant& src, Cpl::Dm::ModelPoint::LockRequest_T lockRequest, uint16_t& retSequenceNumber, Cpl::Text::String* errorMsg ) noexcept
     {
         if ( src.is<const char*>() )
         {
             const char* val   = src.as<const char*>();
-            uint16_t    value = 0;
+            WORDSIZE    value = 0;
             if ( Cpl::Text::asciiBinaryToBuffer( &value, val, sizeof( value ), OPTION_CPL_DM_MP_BITARRAY_IS_LITTLE_ENDIAN ) > 0 )
             {
                 retSequenceNumber = Numeric<WORDSIZE, MPTYPE>::write( value, lockRequest );
@@ -317,29 +317,29 @@ protected:
 
     /// Constructor. Valid MP.  Requires an initial value
     Pointer_( Cpl::Dm::ModelDatabase& myModelBase, const char* symbolicName, void* initialValue )
-        : Numeric<size_t, MPTYPE>( myModelBase, symbolicName, (size_t) initialValue )
+        : Numeric<size_t, MPTYPE>( myModelBase, symbolicName, (size_t)initialValue )
     {
     }
 
 public:
-    /// See Cpl::Dm::Point.  
+    /// See Cpl::Dm::Point.
     void setJSONVal( JsonDocument& doc ) noexcept
     {
         Cpl::Text::FString<20> tmp;
-        tmp.format( PRINTF_SIZET_FMT, (PRINTF_SIZET_TYPE) Numeric<size_t, MPTYPE>::m_data );
-        doc["val"] = (char*) tmp.getString();
+        tmp.format( PRINTF_SIZET_FMT, (PRINTF_SIZET_TYPE)Numeric<size_t, MPTYPE>::m_data );
+        doc["val"] = (char*)tmp.getString();
     }
 
-    /// See Cpl::Dm::Point.  
+    /// See Cpl::Dm::Point.
     bool fromJSON_( JsonVariant& src, Cpl::Dm::ModelPoint::LockRequest_T lockRequest, uint16_t& retSequenceNumber, Cpl::Text::String* errorMsg ) noexcept
     {
         if ( src.is<const char*>() )
         {
-            const char*         val   = src.as<const char*>();
-            unsigned long long  value = 0;
-            if ( Cpl::Text::a2ull( value, val, 16 )  )
+            const char*        val   = src.as<const char*>();
+            unsigned long long value = 0;
+            if ( Cpl::Text::a2ull( value, val, 16 ) )
             {
-                retSequenceNumber = Numeric<size_t, MPTYPE>::write( (size_t) value, lockRequest );
+                retSequenceNumber = Numeric<size_t, MPTYPE>::write( (size_t)value, lockRequest );
                 return true;
             }
         }
@@ -352,7 +352,7 @@ public:
     }
 };
 
-};      // end namespaces
+};  // end namespaces
 };
 };
 #endif  // end header latch

--- a/src/Cpl/Dm/Mp/_0test/bitarray32.cpp
+++ b/src/Cpl/Dm/Mp/_0test/bitarray32.cpp
@@ -1,0 +1,153 @@
+/*-----------------------------------------------------------------------------
+* This file is part of the Colony.Core Project.  The Colony.Core Project is an
+* open source project with a BSD type of licensing agreement.  See the license
+* agreement (license.txt) in the top/ directory or on the Internet at
+* http://integerfox.com/colony.core/license.txt
+*
+* Copyright (c) 2014-2022  John T. Taylor
+*
+* Redistributions of the source code must retain the above copyright notice.
+*----------------------------------------------------------------------------*/
+
+#include "Catch/catch.hpp"
+#include "Cpl/System/_testsupport/Shutdown_TS.h"
+#include "Cpl/System/Trace.h"
+#include "Cpl/System/Api.h"
+#include "Cpl/Text/FString.h"
+#include "Cpl/Text/DString.h"
+#include "Cpl/Dm/ModelDatabase.h"
+#include "Cpl/Dm/Mp/BitArray32.h"
+#include <string.h>
+
+#define STRCMP(s1,s2)       (strcmp(s1,s2)==0)
+#define MAX_STR_LENG        1024
+#define SECT_               "_0test"
+
+#define INITIAL_VALUE       0xAA
+
+////////////////////////////////////////////////////////////////////////////////
+using namespace Cpl::Dm;
+
+// Allocate/create my Model Database
+static ModelDatabase    modelDb_( "ignoreThisParameter_usedToInvokeTheStaticConstructor" );
+
+// Allocate my Model Points
+static Mp::BitArray32       mp_apple_( modelDb_, "APPLE" );
+static Mp::BitArray32       mp_orange_( modelDb_, "ORANGE", INITIAL_VALUE );
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Note: The bare minimum I need to test code that is 'new' to concrete MP type
+//
+TEST_CASE( "BitArray32" )
+{
+    Cpl::System::Shutdown_TS::clearAndUseCounter();
+
+    Cpl::Text::DString  errorMsg( "noerror", 1024 );
+    char                string[MAX_STR_LENG + 1];
+    bool                truncated;
+    bool                valid;
+    uint32_t            value;
+
+    SECTION( "gets" )
+    {
+        // Gets...
+        const char* name = mp_apple_.getName();
+        REQUIRE( strcmp( name, "APPLE" ) == 0 );
+
+        size_t s = mp_apple_.getSize();
+        REQUIRE( s == sizeof( value ) );
+
+        s = mp_apple_.getExternalSize();
+        REQUIRE( s == sizeof( value ) + sizeof( bool ) );
+
+        const char* mpType = mp_apple_.getTypeAsText();
+        CPL_SYSTEM_TRACE_MSG( SECT_, ("typeText: [%s]", mpType) );
+        REQUIRE( strcmp( mpType, "Cpl::Dm::Mp::BitArray32" ) == 0 );
+    }
+
+
+    SECTION( "read/writes" )
+    {
+        // Start with MP in the invalid state
+        mp_apple_.setInvalid();
+
+        mp_apple_.increment( 2 );
+        valid = mp_apple_.read( value );
+        REQUIRE( valid );
+        REQUIRE( value == 2 );  // By design the invalid MP has a 'data value' of zero
+        mp_apple_.write( 1 );
+        valid = mp_apple_.read( value );
+        REQUIRE( valid );
+        REQUIRE( value == 1 );
+
+        valid = mp_orange_.read( value );
+        REQUIRE( valid );
+        REQUIRE( value == INITIAL_VALUE );
+
+        mp_orange_.setBit( 8 );
+        REQUIRE( mp_orange_.read( value ) );
+        REQUIRE( value == 0x1AA );
+
+        mp_orange_.clearBit( 1 );
+        REQUIRE( mp_orange_.read( value ) );
+        REQUIRE( value == 0x1A8  );
+
+        mp_orange_.flipBit( 3 );
+        REQUIRE( mp_orange_.read( value ) );
+        REQUIRE( value == 0x1A0  );
+
+        mp_orange_.setBitsByMask( 0x5501 );
+        REQUIRE( mp_orange_.read( value ) );
+        REQUIRE( value == 0x55A1);
+
+        mp_orange_.clearBitsByMask( 0xF000 );
+        REQUIRE( mp_orange_.read( value ) );
+        REQUIRE( value == 0x05A1  );
+
+        mp_orange_.flipBitsByMask( 0x7701 );
+        REQUIRE( mp_orange_.read( value ) );
+        REQUIRE( value == 0x72A0  );
+    }
+
+    SECTION( "toJSON-pretty" )
+    {
+        mp_apple_.write( 0x82001082 );
+        mp_apple_.toJSON( string, MAX_STR_LENG, truncated, true, true );
+        CPL_SYSTEM_TRACE_MSG( SECT_, ("toJSON: [%s]", string) );
+
+        StaticJsonDocument<1024> doc;
+        DeserializationError err = deserializeJson( doc, string );
+        REQUIRE( err == DeserializationError::Ok );
+        REQUIRE( doc["locked"] == false );
+        REQUIRE( doc["valid"] == true );
+        REQUIRE( STRCMP( doc["val"], "10000010000000000001000010000010") );
+    }
+
+    SECTION( "fromJSON" )
+    {
+        // Start with MP in the invalid state
+        mp_apple_.setInvalid();
+
+        const char* json = "{name:\"APPLE\", val:\"10000010000000000001000010000010\"}";
+        bool result = modelDb_.fromJSON( json );
+        REQUIRE( result == true );
+        valid = mp_apple_.read( value );
+        REQUIRE( valid );
+        REQUIRE( value == 0x82001082 );
+
+        json = "{name:\"APPLE\", val:123}";
+        result = modelDb_.fromJSON( json, &errorMsg );
+        REQUIRE( result == false );
+        REQUIRE( errorMsg != "noerror" );
+
+        json = "{name:\"APPLE\", val:123}";
+        result = modelDb_.fromJSON( json );
+        REQUIRE( result == false );
+    }
+
+    REQUIRE( Cpl::System::Shutdown_TS::getAndClearCounter() == 0u );
+}
+

--- a/src/Cpl/Dm/TShell/Dm.cpp
+++ b/src/Cpl/Dm/TShell/Dm.cpp
@@ -21,7 +21,7 @@ using namespace Cpl::Dm::TShell;
 
 
 ///////////////////////////
-Dm::Dm( Cpl::Container::Map<Cpl::TShell::Command>&  commandList,
+Dm::Dm( Cpl::Container::SList<Cpl::TShell::Command>&  commandList,
 		Cpl::Dm::ModelDatabaseApi&                  modelDatabase,
 		const char*                                 cmdNameAndDatabaseNumber,
 		Cpl::TShell::Security::Permission_T         minPermLevel ) noexcept

--- a/src/Cpl/Dm/TShell/Dm.h
+++ b/src/Cpl/Dm/TShell/Dm.h
@@ -68,7 +68,7 @@ public:
 
 public:
     /// Constructor
-    Dm( Cpl::Container::Map<Cpl::TShell::Command>&  commandList, 
+    Dm( Cpl::Container::SList<Cpl::TShell::Command>&  commandList, 
         Cpl::Dm::ModelDatabaseApi&                  modelDatabase, 
         const char*                                 cmdNameAndDatabaseNumber="dm",
         Cpl::TShell::Security::Permission_T         minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;

--- a/src/Cpl/Dm/TShell/_0test/helpers.h
+++ b/src/Cpl/Dm/TShell/_0test/helpers.h
@@ -106,7 +106,7 @@ public:
 
 public:
 	/// Constructor
-	Bob( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Apple& application ) noexcept
+	Bob( Cpl::Container::SList<Cpl::TShell::Command>& commandList, Apple& application ) noexcept
 		:Command( commandList, "bob" )
 		, m_app( application )
 	{

--- a/src/Cpl/Dm/TShell/_0test/statics.h
+++ b/src/Cpl/Dm/TShell/_0test/statics.h
@@ -20,7 +20,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern Cpl::Container::Map<Cpl::TShell::Command>   cmdlist;
+extern Cpl::Container::SList<Cpl::TShell::Command>   cmdlist;
 
 static Cpl::TShell::Maker cmdProcessor_( cmdlist );
 

--- a/src/Cpl/Io/File/Littlefs/README.txt
+++ b/src/Cpl/Io/File/Littlefs/README.txt
@@ -48,6 +48,8 @@ which littlefs to use).  For example:
 NOTE: The following edits need to be made to the littlefs repo to be 
       build without warnings when using the Microsoft Compiler
 
+      \code
+
       File: lfs.c, lfs_utils.h
         Add the following #ifdef at the top of the file
             // EDIT: JTT - Added this to suppress warning when using the Visual Studio compiler
@@ -61,6 +63,8 @@ NOTE: The following edits need to be made to the littlefs repo to be
             #ifdef _MSC_VER
             #pragma warning( disable : 4146 )
             #endif
+
+     \endcode
 */  
 
 

--- a/src/Cpl/Io/File/Littlefs/README.txt
+++ b/src/Cpl/Io/File/Littlefs/README.txt
@@ -45,6 +45,22 @@ which littlefs to use).  For example:
     Cpl::Io::File::Api::createDirectory( "/A/mydirectory" );    // Created on volume1
 
 
+NOTE: The following edits need to be made to the littlefs repo to be 
+      build without warnings when using the Microsoft Compiler
+
+      File: lfs.c, lfs_utils.h
+        Add the following #ifdef at the top of the file
+            // EDIT: JTT - Added this to suppress warning when using the Visual Studio compiler
+            #ifdef _MSC_VER
+            #pragma warning( disable : 4244 4804 )
+            #endif
+
+      File: lfs_utils.h
+        Add the following #ifdef at the top of the file
+            // EDIT: JTT - Added this to suppress warning when using the Visual Studio compiler
+            #ifdef _MSC_VER
+            #pragma warning( disable : 4146 )
+            #endif
 */  
 
 

--- a/src/Cpl/Io/File/Littlefs/TShell/Fs.cpp
+++ b/src/Cpl/Io/File/Littlefs/TShell/Fs.cpp
@@ -56,7 +56,7 @@ public:
 }  // end anonymous namespace
 
 ///////////////////////////
-Fs::Fs( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+Fs::Fs( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
         unsigned                                   numVolumes,
         const char*                                volumeRootPaths[],
         Cpl::TShell::Security::Permission_T        minPermLevel ) noexcept

--- a/src/Cpl/Io/File/Littlefs/TShell/Fs.h
+++ b/src/Cpl/Io/File/Littlefs/TShell/Fs.h
@@ -82,7 +82,7 @@ public:
 
 public:
     /// Constructor
-    Fs( Cpl::Container::Map<Cpl::TShell::Command>&  commandList, 
+    Fs( Cpl::Container::SList<Cpl::TShell::Command>&  commandList, 
         unsigned                                    numVolumes,
         const char*                                 volumeRootPaths[],
         Cpl::TShell::Security::Permission_T         minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;

--- a/src/Cpl/Io/File/Littlefs/TShell/_0test/test1.cpp
+++ b/src/Cpl/Io/File/Littlefs/TShell/_0test/test1.cpp
@@ -19,6 +19,7 @@
 #include "Cpl/Io/File/Output.h"
 #include "Cpl/Io/File/Littlefs/TShell/Fs.h"
 #include "Cpl/TShell/Stdio.h"
+#include "Cpl/System/Api.h"
 
 #define ROOT_VOL1_PATH "/apple"
 #define ROOT_VOL2_PATH "/orange"
@@ -26,7 +27,7 @@
 ///
 extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
-extern Cpl::Container::Map<Cpl::TShell::Command> cmdlist;
+extern Cpl::Container::SList<Cpl::TShell::Command> cmdlist;
 
 static Cpl::TShell::Maker cmdProcessor_( cmdlist );
 

--- a/src/Cpl/Io/Serial/ST/M32F4/StreamDriver.cpp
+++ b/src/Cpl/Io/Serial/ST/M32F4/StreamDriver.cpp
@@ -19,7 +19,7 @@ using namespace Cpl::Io::Serial::ST::M32F4;
 StreamDriver::HalMapping_T Cpl::Io::Serial::ST::M32F4::StreamDriver::m_mappings[OPTION_CPL_IO_SERIAL_ST_M32F4_MAX_UARTS] = { 0, };
 
 #define ENTER_CRITICAL_SECTION()    do { Cpl::System::Api::suspendScheduling(); Bsp_NVIC_disableIRQ( m_uartIrqNum ); } while(0)
-#define EXIT_CRITICAL_SECTION()     do { Cpl::System::Api::resumeScheduling(); Bsp_NVIC_enableIRQ( m_uartIrqNum ); } while (0)
+#define EXIT_CRITICAL_SECTION()     do { Bsp_NVIC_enableIRQ( m_uartIrqNum ); Cpl::System::Api::resumeScheduling(); } while (0)
 
 ////////////////////////
 StreamDriver::StreamDriver( Cpl::Container::RingBuffer<uint8_t>& txBuffer,

--- a/src/Cpl/Logging/TShell/Log.cpp
+++ b/src/Cpl/Logging/TShell/Log.cpp
@@ -48,7 +48,7 @@ static void createLogEntry( const char* catString, uint32_t catId, const char* m
 
 
 ///////////////////////////
-Log::Log( Cpl::Container::Map<Cpl::TShell::Command>&                         commandList,
+Log::Log( Cpl::Container::SList<Cpl::TShell::Command>&                         commandList,
           Cpl::Itc::PostApi&                                                 logEntryServerMailbox,
           Cpl::Persistent::IndexedEntryServer<Cpl::Logging::EntryData_T>&    logEntryServer,
           Cpl::TShell::Security::Permission_T                                minPermLevel ) noexcept

--- a/src/Cpl/Logging/TShell/Log.h
+++ b/src/Cpl/Logging/TShell/Log.h
@@ -67,7 +67,7 @@ public:
 
 public:
     /// Constructor
-    Log( Cpl::Container::Map<Cpl::TShell::Command>&                         commandList, 
+    Log( Cpl::Container::SList<Cpl::TShell::Command>&                         commandList, 
          Cpl::Itc::PostApi&                                                 logEntryServerMailbox,
          Cpl::Persistent::IndexedEntryServer<Cpl::Logging::EntryData_T>&    logEntryServer,
          Cpl::TShell::Security::Permission_T                                minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;

--- a/src/Cpl/Logging/TShell/_0test/test1.cpp
+++ b/src/Cpl/Logging/TShell/_0test/test1.cpp
@@ -155,7 +155,7 @@ public:
 
 public:
     /// Constructor
-    ShutdownHack( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Cpl::TShell::Security::Permission_T minPerm = Cpl::TShell::Security::ePUBLIC ) noexcept
+    ShutdownHack( Cpl::Container::SList<Cpl::TShell::Command>& commandList, Cpl::TShell::Security::Permission_T minPerm = Cpl::TShell::Security::ePUBLIC ) noexcept
         :Command( commandList, "shutdown", minPerm )
     {
     }
@@ -178,7 +178,7 @@ public:
 } // end anonymous namespace
 ///////////////////////////////////////
 
-static Cpl::Container::Map<Cpl::TShell::Command>	cmdlist_;
+static Cpl::Container::SList<Cpl::TShell::Command>	cmdlist_;
 static Cpl::TShell::Maker							cmdProcessor_( cmdlist_ );
 static Cpl::TShell::Stdio							shell_( cmdProcessor_ );
 static Cpl::TShell::Cmd::Help						helpCmd_( cmdlist_ );

--- a/src/Cpl/MApp/Cmd.cpp
+++ b/src/Cpl/MApp/Cmd.cpp
@@ -16,7 +16,7 @@ using namespace Cpl::MApp;
 #define SUBCMD_LIST     "ls"
 
 ///////////////////////////
-Cmd::Cmd( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Cpl::MApp::ManagerApi& mappManager ) noexcept
+Cmd::Cmd( Cpl::Container::SList<Cpl::TShell::Command>& commandList, Cpl::MApp::ManagerApi& mappManager ) noexcept
     : Cpl::TShell::Cmd::Command( commandList, verb )
     , m_mappManager( mappManager )
 {

--- a/src/Cpl/MApp/Cmd.h
+++ b/src/Cpl/MApp/Cmd.h
@@ -53,7 +53,7 @@ public:
 
 public:
     /// Constructor
-    Cmd( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Cpl::MApp::ManagerApi& mappManager ) noexcept;
+    Cmd( Cpl::Container::SList<Cpl::TShell::Command>& commandList, Cpl::MApp::ManagerApi& mappManager ) noexcept;
 
 
 public:

--- a/src/Cpl/MApp/MAppApi.h
+++ b/src/Cpl/MApp/MAppApi.h
@@ -7,7 +7,7 @@
 
 
 #include "colony_config.h"
-#include "Cpl/Container/MapItem.h"
+#include "Cpl/Container/Item.h"
 
 
 /// CPL Trace Section identifier for a common trace output section
@@ -33,7 +33,7 @@ namespace MApp {
         o The application can safely pass initial settings, configuration, 
           options when the MApp is started
  */
-class MAppApi : public Cpl::Container::MapItem
+class MAppApi : public Cpl::Container::Item
 {
 public:
     /** This method returns the MApp name.  The MApp name must an printable

--- a/src/Cpl/MApp/MApp_.cpp
+++ b/src/Cpl/MApp/MApp_.cpp
@@ -7,7 +7,7 @@
 
 using namespace Cpl::MApp;
 
-MApp_::MApp_( Cpl::Container::Map<MAppApi>&   mappList,
+MApp_::MApp_( Cpl::Container::SList<MAppApi>& mappList,
               const char*                     mappName,
               const char*                     description,
               const char*                     usage )
@@ -16,12 +16,12 @@ MApp_::MApp_( Cpl::Container::Map<MAppApi>&   mappList,
     , m_usage( usage )
     , m_started( false )
 {
-    mappList.insert( *this );
+    mappList.put( *this );
 }
 
 const char* MApp_::getName() const noexcept
 {
-    return m_name.getKeyValue();
+    return m_name;
 }
 
 const char* MApp_::getDescription() const noexcept
@@ -32,9 +32,4 @@ const char* MApp_::getDescription() const noexcept
 const char* MApp_::getUsage() const noexcept
 {
     return m_usage;
-}
-
-const Cpl::Container::Key& MApp_::getKey() const noexcept
-{
-    return m_name;
 }

--- a/src/Cpl/MApp/MApp_.h
+++ b/src/Cpl/MApp/MApp_.h
@@ -7,7 +7,7 @@
 
 
 #include "Cpl/MApp/MAppApi.h"
-#include "Cpl/Container/Map.h"
+#include "Cpl/Container/SList.h"
 
 /*----------------------------------------------------------------------------*/
 ///
@@ -22,11 +22,11 @@ namespace MApp {
 class MApp_ : public MAppApi
 {
 protected:
-    /// Constructor.  
-    MApp_( Cpl::Container::Map<MAppApi>&  mappList,
-           const char*                    mappName,
-           const char*                    description,
-           const char*                    usage );
+    /// Constructor.
+    MApp_( Cpl::Container::SList<MAppApi>& mappList,
+           const char*                     mappName,
+           const char*                     description,
+           const char*                     usage );
 
 public:
     /// See Cpl::MApp::Api
@@ -39,12 +39,8 @@ public:
     const char* getUsage() const noexcept;
 
 protected:
-    /// See Cpl::Container::Key
-    const Cpl::Container::Key& getKey() const noexcept;
-
-protected:
     /// Command name
-    Cpl::Container::KeyLiteralString    m_name;
+    const char* m_name;
 
     /// Description
     const char* m_description;
@@ -53,9 +49,9 @@ protected:
     const char* m_usage;
 
     /// Started state
-    bool        m_started;
+    bool m_started;
 };
 
-};      // end namespaces
+};  // end namespaces
 };
 #endif  // end header latch

--- a/src/Cpl/MApp/Manager.h
+++ b/src/Cpl/MApp/Manager.h
@@ -10,7 +10,7 @@
 #include "Cpl/Dm/MailboxServer.h"
 #include "Cpl/MApp/ManagerApi.h"
 #include "Cpl/MApp/Requests.h"
-#include "Cpl/Container/Map.h"
+#include "Cpl/Container/SList.h"
 
 ///
 namespace Cpl {
@@ -35,7 +35,7 @@ class Manager:
 public:
     /// Constructor
     Manager( Cpl::Dm::MailboxServer&       myMbox, 
-             Cpl::Container::Map<MAppApi>& listOfMApps );
+             Cpl::Container::SList<MAppApi>& listOfMApps );
 
     /// Destructor
     ~Manager() {}
@@ -89,10 +89,10 @@ public:
 
 protected:
     /// List of inactive MApps
-    Cpl::Container::Map<MAppApi>& m_inactiveMApps;
+    Cpl::Container::SList<MAppApi>& m_inactiveMApps;
 
     /// List of started MApps
-    Cpl::Container::Map<MAppApi>  m_startedMApps;
+    Cpl::Container::SList<MAppApi>  m_startedMApps;
 
     /// My open/close state
     bool                          m_opened;

--- a/src/Cpl/MApp/Temperature/Api.cpp
+++ b/src/Cpl/MApp/Temperature/Api.cpp
@@ -12,7 +12,7 @@
 using namespace Cpl::MApp::Temperature;
 
 /////////////////////////////////////////////////////
-Api::Api( Cpl::Container::Map<MAppApi>&    mappList,
+Api::Api( Cpl::Container::SList<MAppApi>&    mappList,
           Cpl::Dm::MailboxServer&          myMbox,
           Cpl::Dm::Mp::Float&              srcTemperatureMp,
           const char*                      name )
@@ -44,7 +44,7 @@ bool Api::start_( char* args ) noexcept
     }
 
     CPL_SYSTEM_TRACE_MSG( OPTION_CPL_MAPP_TRACE_SECTION, ("%s: Configuration: sampleMs=%u ms, displayMs=%u ms, units=%s",
-                                                           m_name.getKeyValue(),
+                                                           m_name,
                                                            m_sampleMs,
                                                            m_displayMs,
                                                            m_fahrenheit ? "'F" : "'C") );
@@ -169,7 +169,7 @@ void Api::expired( void ) noexcept
             }
 
             CPL_SYSTEM_TRACE_MSG( OPTION_CPL_MAPP_TRACE_SECTION, ("%s: %g '%c, avg: %g '%c, min: %g '%c, max: %g '%c",
-                                                                   m_name.getKeyValue(),
+                                                                   m_name,
                                                                    displayTemp, units,
                                                                    avgTemp, units,
                                                                    minTemp, units,
@@ -180,7 +180,7 @@ void Api::expired( void ) noexcept
     else if ( !m_invalidData )
     {
         m_invalidData = true;
-        CPL_SYSTEM_TRACE_MSG( OPTION_CPL_MAPP_TRACE_SECTION, ("%s: <data invalid>", m_name.getKeyValue()) );
+        CPL_SYSTEM_TRACE_MSG( OPTION_CPL_MAPP_TRACE_SECTION, ("%s: <data invalid>", m_name) );
     }
 
     // Restart my timer

--- a/src/Cpl/MApp/Temperature/Api.h
+++ b/src/Cpl/MApp/Temperature/Api.h
@@ -72,7 +72,7 @@ public:
 
 public:
     /// Constructor. Note: The myMbox argument is only needed because the class uses a SW timer
-    Api( Cpl::Container::Map<MAppApi>&    mappList,
+    Api( Cpl::Container::SList<MAppApi>&    mappList,
          Cpl::Dm::MailboxServer&          myMbox,
          Cpl::Dm::Mp::Float&              srcTemperatureMp,
          const char*                      name = DEFAULT_NAME );

--- a/src/Cpl/MApp/_0test/manager.cpp
+++ b/src/Cpl/MApp/_0test/manager.cpp
@@ -17,42 +17,40 @@
 #include "Cpl/System/Shutdown.h"
 
 
+#define SECT_ "_0test"
 
-#define SECT_     "_0test"
-
-/// 
+///
 using namespace Cpl::MApp;
 
 
+///
+extern void                                        runtest( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
-/// 
-extern void runtest( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
+extern Cpl::Container::SList<Cpl::TShell::Command> cmdlist;
 
-extern Cpl::Container::Map<Cpl::TShell::Command>   cmdlist;
+static Cpl::TShell::Maker                          cmdProcessor_( cmdlist );
+static Cpl::TShell::Stdio                          shell_( cmdProcessor_ );
 
-static Cpl::TShell::Maker       cmdProcessor_( cmdlist );
-static Cpl::TShell::Stdio       shell_( cmdProcessor_ );
-
-static Cpl::TShell::Cmd::Help	helpCmd_( cmdlist );
-static Cpl::TShell::Cmd::Bye	byeCmd_( cmdlist );
-static Cpl::TShell::Cmd::Trace	traceCmd_( cmdlist );
-static Cpl::TShell::Cmd::TPrint	tprintCmd_( cmdlist );
+static Cpl::TShell::Cmd::Help                      helpCmd_( cmdlist );
+static Cpl::TShell::Cmd::Bye                       byeCmd_( cmdlist );
+static Cpl::TShell::Cmd::Trace                     traceCmd_( cmdlist );
+static Cpl::TShell::Cmd::TPrint                    tprintCmd_( cmdlist );
 
 // Allocate/create my Model Database
-static Cpl::Dm::ModelDatabase    modelDb_( "ignoreThisParameter_usedToInvokeTheStaticConstructor" );
+static Cpl::Dm::ModelDatabase modelDb_( "ignoreThisParameter_usedToInvokeTheStaticConstructor" );
 
 // Allocate my Model Points
-static Cpl::Dm::Mp::Float        mp_apple_( modelDb_, "apple" );
-static Cpl::Dm::Mp::Float        mp_orange_( modelDb_, "orange" );
-static Cpl::Dm::Mp::Float        mp_cherry_( modelDb_, "cherry" );
+static Cpl::Dm::Mp::Float                        mp_apple_( modelDb_, "apple" );
+static Cpl::Dm::Mp::Float                        mp_orange_( modelDb_, "orange" );
+static Cpl::Dm::Mp::Float                        mp_cherry_( modelDb_, "cherry" );
 
-static Cpl::Dm::TShell::Dm	    dmCmd_( cmdlist, modelDb_ );
+static Cpl::Dm::TShell::Dm                       dmCmd_( cmdlist, modelDb_ );
 
 
-static Cpl::Dm::MailboxServer   mappMbox_;
+static Cpl::Dm::MailboxServer                    mappMbox_;
 
-static Cpl::Container::Map<Cpl::MApp::MAppApi>   mappList_;
+static Cpl::Container::SList<Cpl::MApp::MAppApi> mappList_;
 static Cpl::MApp::Manager                        mappManager_( mappMbox_, mappList_ );
 static Cpl::MApp::Cmd                            mappCmd_( cmdlist, mappManager_ );
 
@@ -64,7 +62,7 @@ static Cpl::MApp::Temperature::Api               t3_( mappList_, mappMbox_, mp_c
 ////////////////////////////////////////////////////////////////////
 static Cpl::System::Semaphore shutdownWaiter_;
 static int                    exitCode_;
-static void waitForShutdown();
+static void                   waitForShutdown();
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -75,7 +73,7 @@ void runtest( Cpl::Io::Input& infd, Cpl::Io::Output& outfd )
     CPL_SYSTEM_TRACE_ENABLE_SECTION( OPTION_CPL_MAPP_TRACE_SECTION );
 
     // Create thread for the MApp instances to run in
-    Cpl::System::Thread* t1 =  Cpl::System::Thread::create( mappMbox_, "MAPPS" );
+    Cpl::System::Thread* t1 = Cpl::System::Thread::create( mappMbox_, "MAPPS" );
 
     // Initialize some (but not all) MPs
     mp_apple_.write( 3.14F );
@@ -104,7 +102,7 @@ void runtest( Cpl::Io::Input& infd, Cpl::Io::Output& outfd )
 //////////////////////////////////////////////////////////////////////
 void waitForShutdown()
 {
-    // Wait till I am signaled 
+    // Wait till I am signaled
     shutdownWaiter_.wait();
 }
 

--- a/src/Cpl/System/_testsupport/Shutdown_TS.cpp
+++ b/src/Cpl/System/_testsupport/Shutdown_TS.cpp
@@ -1,13 +1,13 @@
 /*-----------------------------------------------------------------------------
-* This file is part of the Colony.Core Project.  The Colony.Core Project is an
-* open source project with a BSD type of licensing agreement.  See the license
-* agreement (license.txt) in the top/ directory or on the Internet at
-* http://integerfox.com/colony.core/license.txt
-*
-* Copyright (c) 2014-2022  John T. Taylor
-*
-* Redistributions of the source code must retain the above copyright notice.
-*----------------------------------------------------------------------------*/
+ * This file is part of the Colony.Core Project.  The Colony.Core Project is an
+ * open source project with a BSD type of licensing agreement.  See the license
+ * agreement (license.txt) in the top/ directory or on the Internet at
+ * http://integerfox.com/colony.core/license.txt
+ *
+ * Copyright (c) 2014-2022  John T. Taylor
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
 
 #include "Shutdown_TS.h"
 #include "Cpl/System/Shutdown.h"
@@ -79,7 +79,15 @@ static int preprocess_shutdown_( int exit_code, bool& true_exit )
         if ( counting_ )
         {
             counter_++;
-            true_exit = false;
+            if ( counter_ < OPTION_CPL_SYSTEM_SHUTDOWN_TS_MAX_FATAL_ERRORS )
+            {
+                true_exit = false;
+            }
+            else
+            {
+                true_exit = true;
+                exit_code = exitCode_;
+            }
         }
         else
         {
@@ -118,8 +126,3 @@ int Shutdown::failure( int exit_code )
 
     return exit_code;
 }
-
-
-
-
-

--- a/src/Cpl/System/_testsupport/Shutdown_TS.h
+++ b/src/Cpl/System/_testsupport/Shutdown_TS.h
@@ -12,8 +12,19 @@
 *----------------------------------------------------------------------------*/
 /** @file */
 
+#include "colony_config.h"
 #include <stddef.h>
 
+/** Maximum number of allowed fatal errors before the application is
+    forced to exit.  This is a safety mechanism to prevent the unit test
+    from getting into a 'runaway' error condition.  
+
+    Note: The fatal error count is reset everytime getAndClearCounter() 
+          is called.
+ */
+#ifndef OPTION_CPL_SYSTEM_SHUTDOWN_TS_MAX_FATAL_ERRORS 
+#define OPTION_CPL_SYSTEM_SHUTDOWN_TS_MAX_FATAL_ERRORS  30
+#endif
 
 /// 
 namespace Cpl {

--- a/src/Cpl/TShell/Cmd/Bye.cpp
+++ b/src/Cpl/TShell/Cmd/Bye.cpp
@@ -20,7 +20,7 @@
 using namespace Cpl::TShell::Cmd;
 
 ///////////////////////////
-Bye::Bye( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+Bye::Bye( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
 		  Security::Permission_T                     minPermLevel ) noexcept
 	:Command( commandList, verb, minPermLevel )
 {

--- a/src/Cpl/TShell/Cmd/Bye.h
+++ b/src/Cpl/TShell/Cmd/Bye.h
@@ -52,7 +52,7 @@ protected:
 
 public:
     /// Constructor
-    Bye( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+    Bye( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
          Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 public:

--- a/src/Cpl/TShell/Cmd/Command.cpp
+++ b/src/Cpl/TShell/Cmd/Command.cpp
@@ -17,20 +17,20 @@ using namespace Cpl::TShell::Cmd;
 
 
 ////////////////////////////
-Command::Command( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+Command::Command( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
 				  const char*                                verb,
 				  Security::Permission_T                     minPermLevel ) noexcept
-	: m_mapKey( verb )
+	: m_verb( verb )
 	, m_minPermissionLevel( minPermLevel )
 {
-	commandList.insert( *this );
+	commandList.put( *this );
 }
 
 
 ////////////////////////////
 const char* Command::getVerb() const noexcept
 {
-	return m_mapKey.getKeyValue();
+	return m_verb;
 }
 
 Cpl::TShell::Security::Permission_T Command::getMinPermissionRequired() const noexcept
@@ -38,7 +38,3 @@ Cpl::TShell::Security::Permission_T Command::getMinPermissionRequired() const no
 	return m_minPermissionLevel;
 }
 
-const Cpl::Container::Key& Command::getKey() const noexcept
-{
-	return m_mapKey;
-}

--- a/src/Cpl/TShell/Cmd/Command.h
+++ b/src/Cpl/TShell/Cmd/Command.h
@@ -15,13 +15,11 @@
 #include "colony_config.h"
 #include "Cpl/TShell/Command.h"
 #include "Cpl/TShell/Context_.h"
-#include "Cpl/Container/Map.h"
-#include "Cpl/Text/String.h"
 
 /** Default Permission level for all commands
  */
 #ifndef OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL
-#define OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL	Cpl::TShell::Security::ePUBLIC
+#define OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL Cpl::TShell::Security::ePUBLIC
 #endif
 
 
@@ -38,43 +36,37 @@ namespace Cmd {
 class Command : public Cpl::TShell::Command
 {
 protected:
-	/// Result when processing a conditional statement
-	enum CondResult_T {
-		eFALSE, //!< The conditional statement evaluated to false
-		eTRUE,  //!< The conditional statement evaluated to true
-		eERROR  //!< Error occurring during the evaluation of the conditional
-	};
+    /// Result when processing a conditional statement
+    enum CondResult_T
+    {
+        eFALSE,  //!< The conditional statement evaluated to false
+        eTRUE,   //!< The conditional statement evaluated to true
+        eERROR   //!< Error occurring during the evaluation of the conditional
+    };
 
 protected:
-	/// Command 
-	Cpl::Container::KeyLiteralString	m_mapKey;
+    /// Command verb
+    const char* m_verb;
 
-	/// Minimum required user permission need to execute me
-	Security::Permission_T				m_minPermissionLevel;
+    /// Minimum required user permission need to execute me
+    Security::Permission_T m_minPermissionLevel;
 
 protected:
-	/// Constructor
-	Command( Cpl::Container::Map<Cpl::TShell::Command>& commandList, 
-			 const char*                                verb, 
-			 Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
+    /// Constructor
+    Command( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
+             const char*                                  verb,
+             Security::Permission_T                       minPermLevel = OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 
 public:
-	/// See Cpl::TShell::Command
-	const char* getVerb() const noexcept;
+    /// See Cpl::TShell::Command
+    const char* getVerb() const noexcept;
 
-	/// See Cpl::TShell::Command
-	Security::Permission_T getMinPermissionRequired() const noexcept;
-
-protected:
-	/// See Cpl::Container::Key
-	const Cpl::Container::Key& getKey() const noexcept;
-
-
-
+    /// See Cpl::TShell::Command
+    Security::Permission_T getMinPermissionRequired() const noexcept;
 };
 
-};      // end namespaces
+};  // end namespaces
 };
 };
 #endif  // end header latch

--- a/src/Cpl/TShell/Cmd/FreeRTOS/Threads.cpp
+++ b/src/Cpl/TShell/Cmd/FreeRTOS/Threads.cpp
@@ -20,7 +20,7 @@ static const char* state2text_( eTaskState state );
 
 
 ///////////////////////////
-Threads::Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+Threads::Threads( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
                   Security::Permission_T                     minPermLevel ) noexcept
     :Cpl::TShell::Cmd::Threads( commandList, minPermLevel )
 {

--- a/src/Cpl/TShell/Cmd/FreeRTOS/Threads.h
+++ b/src/Cpl/TShell/Cmd/FreeRTOS/Threads.h
@@ -33,7 +33,7 @@ class Threads : public Cpl::TShell::Cmd::Threads
 {
 public:
 	/// Constructor
-	Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+	Threads( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
 			 Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 

--- a/src/Cpl/TShell/Cmd/Help.cpp
+++ b/src/Cpl/TShell/Cmd/Help.cpp
@@ -22,9 +22,9 @@ static void outputLongText_( Cpl::TShell::Context_& context, bool& io, const cha
 
 
 ///////////////////////////
-Help::Help( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
-			Security::Permission_T                     minPermLevel ) noexcept
-	:Command( commandList, verb, minPermLevel )
+Help::Help( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
+            Security::Permission_T                       minPermLevel ) noexcept
+    : Command( commandList, verb, minPermLevel )
 {
 }
 
@@ -32,83 +32,82 @@ Help::Help( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
 ///////////////////////////
 Cpl::TShell::Command::Result_T Help::execute( Cpl::TShell::Context_& context, char* cmdString, Cpl::Io::Output& outfd ) noexcept
 {
-	Cpl::Text::Tokenizer::TextBlock tokens( cmdString, context.getDelimiterChar(), context.getTerminatorChar(), context.getQuoteChar(), context.getEscapeChar() );
+    Cpl::Text::Tokenizer::TextBlock tokens( cmdString, context.getDelimiterChar(), context.getTerminatorChar(), context.getQuoteChar(), context.getEscapeChar() );
 
-	// Error checking
-	if ( tokens.numParameters() > 2 )
-	{
-		return Command::eERROR_EXTRA_ARGS;
-	}
+    // Error checking
+    if ( tokens.numParameters() > 2 )
+    {
+        return Command::eERROR_EXTRA_ARGS;
+    }
 
-	// Housekeeping
-	Cpl::Container::Map<Cpl::TShell::Command>&  cmdList = context.getCommands();
-	bool                                        io      = true;
-	Cpl::TShell::Command*                       cmdPtr;
-	Cpl::Container::KeyLiteralString            verb( tokens.getParameter( 1 ) );
+    // Housekeeping
+    bool                  io = true;
+    Cpl::TShell::Command* cmdPtr;
+    const char*           verb = tokens.getParameter( 1 );
 
-	// Command specific help
-	if ( ( cmdPtr=cmdList.find( verb ) ) )
-	{
-		if ( cmdPtr->getMinPermissionRequired() <= context.getUserPermissionLevel() )
-		{
-			outputCmdHelp_( context, *cmdPtr, io, true );
-		}
-	}
+    // Command specific help
+    if ( verb != nullptr && ( cmdPtr = context.findCommand( verb, strlen( verb ) ) ) )
+    {
+        if ( cmdPtr->getMinPermissionRequired() <= context.getUserPermissionLevel() )
+        {
+            outputCmdHelp_( context, *cmdPtr, io, true );
+        }
+    }
 
-	// List the commands
-	else
-	{
-		cmdPtr = cmdList.first();
+    // List the commands
+    else
+    {
+        Cpl::Container::SList<Cpl::TShell::Command>& cmdList = context.getCommands();
+        cmdPtr                                               = cmdList.first();
 
-		while ( cmdPtr && io == true )
-		{
-			if ( cmdPtr->getMinPermissionRequired() <= context.getUserPermissionLevel() )
-			{
-				outputCmdHelp_( context, *cmdPtr, io, tokens.numParameters() == 2 );
-			}
-			cmdPtr = cmdList.next( *cmdPtr );
-		}
-	}
+        while ( cmdPtr && io == true )
+        {
+            if ( cmdPtr->getMinPermissionRequired() <= context.getUserPermissionLevel() )
+            {
+                outputCmdHelp_( context, *cmdPtr, io, tokens.numParameters() == 2 );
+            }
+            cmdPtr = cmdList.next( *cmdPtr );
+        }
+    }
 
-	return io ? Command::eSUCCESS : Command::eERROR_IO;
+    return io ? Command::eSUCCESS : Command::eERROR_IO;
 }
-
 
 
 void outputCmdHelp_( Cpl::TShell::Context_& context, Cpl::TShell::Command& cmd, bool& io, bool includeDetails )
 {
-	outputLongText_( context, io, cmd.getUsage() );
-	if ( includeDetails )
-	{
-		const char* details = cmd.getHelp();
-		if ( details && *details != '\0' )
-		{
-			outputLongText_( context, io, details );
-			io &= context.writeFrame( " " );
-		}
-	}
+    outputLongText_( context, io, cmd.getUsage() );
+    if ( includeDetails )
+    {
+        const char* details = cmd.getHelp();
+        if ( details && *details != '\0' )
+        {
+            outputLongText_( context, io, details );
+            io &= context.writeFrame( " " );
+        }
+    }
 }
 
 
 void outputLongText_( Cpl::TShell::Context_& context, bool& io, const char* text )
 {
-	const char* ptr = text;
-	while ( *ptr )
-	{
-		if ( *ptr == '\n' )
-		{
-			io &= context.writeFrame( text, ptr - text );
-			text = ++ptr;
-		}
-		else
-		{
-			ptr++;
-		}
-	}
+    const char* ptr = text;
+    while ( *ptr )
+    {
+        if ( *ptr == '\n' )
+        {
+            io   &= context.writeFrame( text, ptr - text );
+            text  = ++ptr;
+        }
+        else
+        {
+            ptr++;
+        }
+    }
 
-	size_t numBytes = ptr - text;
-	if ( numBytes )
-	{
-		io &= context.writeFrame( text, numBytes );
-	}
+    size_t numBytes = ptr - text;
+    if ( numBytes )
+    {
+        io &= context.writeFrame( text, numBytes );
+    }
 }

--- a/src/Cpl/TShell/Cmd/Help.h
+++ b/src/Cpl/TShell/Cmd/Help.h
@@ -55,7 +55,7 @@ public:
 
 public:
     /// Constructor
-    Help( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+    Help( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
           Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 

--- a/src/Cpl/TShell/Cmd/TPrint.cpp
+++ b/src/Cpl/TShell/Cmd/TPrint.cpp
@@ -21,7 +21,7 @@ using namespace Cpl::TShell;
 
 
 ///////////////////////////
-TPrint::TPrint( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+TPrint::TPrint( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
 				Security::Permission_T                     minPermLevel ) noexcept
 	:Command( commandList, verb, minPermLevel )
 {

--- a/src/Cpl/TShell/Cmd/TPrint.h
+++ b/src/Cpl/TShell/Cmd/TPrint.h
@@ -54,7 +54,7 @@ public:
 
 public:
 	/// Constructor
-	TPrint( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+	TPrint( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
             Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 

--- a/src/Cpl/TShell/Cmd/Threads.cpp
+++ b/src/Cpl/TShell/Cmd/Threads.cpp
@@ -20,7 +20,7 @@
 using namespace Cpl::TShell::Cmd;
 
 ///////////////////////////
-Threads::Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+Threads::Threads( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
 				  Security::Permission_T                     minPermLevel ) noexcept
 	:Command( commandList, verb, minPermLevel )
 	, m_contextPtr( 0 )

--- a/src/Cpl/TShell/Cmd/Threads.h
+++ b/src/Cpl/TShell/Cmd/Threads.h
@@ -66,7 +66,7 @@ protected:
 
 public:
 	/// Constructor
-	Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+	Threads( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
 			 Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 public:

--- a/src/Cpl/TShell/Cmd/Tick.cpp
+++ b/src/Cpl/TShell/Cmd/Tick.cpp
@@ -22,7 +22,7 @@
 using namespace Cpl::TShell::Cmd;
 
 ///////////////////////////
-Tick::Tick( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+Tick::Tick( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
             Security::Permission_T                     minPermLevel ) noexcept
     :Command( commandList, verb, minPermLevel )
 {

--- a/src/Cpl/TShell/Cmd/Tick.h
+++ b/src/Cpl/TShell/Cmd/Tick.h
@@ -54,7 +54,7 @@ protected:
 
 public:
     /// Constructor
-    Tick( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+    Tick( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
           Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 public:

--- a/src/Cpl/TShell/Cmd/Trace.cpp
+++ b/src/Cpl/TShell/Cmd/Trace.cpp
@@ -29,7 +29,7 @@ static void dummy_( const char* f1, const char* f2, const char* f3, const char* 
 
 
 ///////////////////////////
-Trace::Trace( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+Trace::Trace( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
 			  Security::Permission_T                     minPermLevel ) noexcept
 	:Command( commandList, verb, minPermLevel )
 {

--- a/src/Cpl/TShell/Cmd/Trace.h
+++ b/src/Cpl/TShell/Cmd/Trace.h
@@ -58,7 +58,7 @@ public:
 
 public:
 	/// Constructor
-	Trace( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+	Trace( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
            Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 public:

--- a/src/Cpl/TShell/Cmd/User.cpp
+++ b/src/Cpl/TShell/Cmd/User.cpp
@@ -18,7 +18,7 @@ using namespace Cpl::TShell::Cmd;
 
 
 ///////////////////////////
-User::User( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Cpl::TShell::Security& validator ) noexcept
+User::User( Cpl::Container::SList<Cpl::TShell::Command>& commandList, Cpl::TShell::Security& validator ) noexcept
     : Command( commandList, verb, Cpl::TShell::Security::ePUBLIC ) // ALWAYS a public command
     , m_validator( validator )
 {

--- a/src/Cpl/TShell/Cmd/User.h
+++ b/src/Cpl/TShell/Cmd/User.h
@@ -54,7 +54,7 @@ public:
 
 public:
     /// Constructor
-    User( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Cpl::TShell::Security& validator ) noexcept;
+    User( Cpl::Container::SList<Cpl::TShell::Command>& commandList, Cpl::TShell::Security& validator ) noexcept;
 
 
 public:

--- a/src/Cpl/TShell/Cmd/Wait.cpp
+++ b/src/Cpl/TShell/Cmd/Wait.cpp
@@ -20,7 +20,7 @@
 using namespace Cpl::TShell::Cmd;
 
 ///////////////////////////
-Wait::Wait( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+Wait::Wait( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
             Security::Permission_T                     minPermLevel ) noexcept
     :Command( commandList, verb, minPermLevel )
 {

--- a/src/Cpl/TShell/Cmd/Wait.h
+++ b/src/Cpl/TShell/Cmd/Wait.h
@@ -51,7 +51,7 @@ protected:
 
 public:
     /// Constructor
-    Wait( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+    Wait( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
           Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 public:

--- a/src/Cpl/TShell/Cmd/Win32/Threads.cpp
+++ b/src/Cpl/TShell/Cmd/Win32/Threads.cpp
@@ -19,7 +19,7 @@ using namespace Cpl::TShell::Cmd::Win32;
 
 
 ///////////////////////////
-Threads::Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+Threads::Threads( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
 				  Security::Permission_T                     minPermLevel ) noexcept
 	:Cpl::TShell::Cmd::Threads( commandList, minPermLevel )
 {

--- a/src/Cpl/TShell/Cmd/Win32/Threads.h
+++ b/src/Cpl/TShell/Cmd/Win32/Threads.h
@@ -33,7 +33,7 @@ class Threads : public Cpl::TShell::Cmd::Threads
 {
 public:
 	/// Constructor
-	Threads( Cpl::Container::Map<Cpl::TShell::Command>& commandList,
+	Threads( Cpl::Container::SList<Cpl::TShell::Command>& commandList,
 			 Security::Permission_T                     minPermLevel=OPTION_TSHELL_CMD_COMMAND_DEFAULT_PERMISSION_LEVEL ) noexcept;
 
 

--- a/src/Cpl/TShell/Cmd/_0test/expected-unix.txt
+++ b/src/Cpl/TShell/Cmd/_0test/expected-unix.txt
@@ -8,8 +8,8 @@ $ ERROR: [bye]
 ERRNO 5: Command encounter 'extra' argument(s)
 $ ERROR: [tprint]
 ERRNO 5: Command encounter 'extra' argument(s)
-$ ERROR: [thread to many args]
-ERRNO 2: Command not supported
+$ ERROR: [thread]
+ERRNO 5: Command encounter 'extra' argument(s)
 $ ERROR: [trace]
 ERRNO 6: One or more Command arguments are incorrect/invalid
 $ ERROR: [help]

--- a/src/Cpl/TShell/Cmd/_0test/expected.txt
+++ b/src/Cpl/TShell/Cmd/_0test/expected.txt
@@ -8,8 +8,8 @@ $ ERROR: [bye]
 ERRNO 5: Command encounter 'extra' argument(s)
 $ ERROR: [tprint]
 ERRNO 5: Command encounter 'extra' argument(s)
-$ ERROR: [thread to many args]
-ERRNO 2: Command not supported
+$ ERROR: [thread]
+ERRNO 5: Command encounter 'extra' argument(s)
 $ ERROR: [trace]
 ERRNO 6: One or more Command arguments are incorrect/invalid
 $ ERROR: [help]

--- a/src/Cpl/TShell/Cmd/_0test/helpers.h
+++ b/src/Cpl/TShell/Cmd/_0test/helpers.h
@@ -107,7 +107,7 @@ public:
 
 public:
 	/// Constructor
-	Bob( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Apple& application ) noexcept
+	Bob( Cpl::Container::SList<Cpl::TShell::Command>& commandList, Apple& application ) noexcept
 		:Command( commandList, "bob" )
 		, m_app( application )
 	{

--- a/src/Cpl/TShell/Cmd/_0test/statics.h
+++ b/src/Cpl/TShell/Cmd/_0test/statics.h
@@ -20,7 +20,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern Cpl::Container::Map<Cpl::TShell::Command>   cmdlist;
+extern Cpl::Container::SList<Cpl::TShell::Command>   cmdlist;
 
 static Cpl::TShell::Maker cmdProcessor_( cmdlist );
 

--- a/src/Cpl/TShell/Command.h
+++ b/src/Cpl/TShell/Command.h
@@ -12,7 +12,7 @@
 *----------------------------------------------------------------------------*/
 /** @file */
 
-#include "Cpl/Container/MapItem.h"
+#include "Cpl/Container/Item.h"
 #include "Cpl/Io/Output.h"
 #include "Cpl/TShell/Security.h"
 
@@ -28,7 +28,7 @@ class Context_;
 
 /** This class defines the interface for a TShell command.
  */
-class Command : public Cpl::Container::MapItem
+class Command : public Cpl::Container::Item
 {
 public:
 	/// Possible result codes when executing a command

--- a/src/Cpl/TShell/Context_.h
+++ b/src/Cpl/TShell/Context_.h
@@ -15,7 +15,7 @@
 #include "Cpl/TShell/ProcessorApi.h"
 #include "Cpl/TShell/Security.h"
 #include "Cpl/TShell/Command.h"
-#include "Cpl/Container/Map.h"
+#include "Cpl/Container/SList.h"
 
 
 ///
@@ -32,7 +32,10 @@ class Context_ : public ProcessorApi
 {
 public:
     /// This method returns the list of implemented commands
-    virtual Cpl::Container::Map<Command>& getCommands() noexcept = 0;
+    virtual Cpl::Container::SList<Command>& getCommands() noexcept = 0;
+
+    /// Lookup a command by its verb.  Returns a nullptr if the command is not found
+    virtual Command* findCommand( const char* verb, size_t verbLength  ) noexcept = 0;
 
 public:
     /// This method encodes and outputs the specified message/text.  The method returns false if there was Output Stream error

--- a/src/Cpl/TShell/Maker.cpp
+++ b/src/Cpl/TShell/Maker.cpp
@@ -16,7 +16,7 @@ using namespace Cpl::TShell;
 
 
 ////////////////////////////////
-Maker::Maker( Cpl::Container::Map<Command>& cmdlist, Cpl::System::Mutex& lock )
+Maker::Maker( Cpl::Container::SList<Command>& cmdlist, Cpl::System::Mutex& lock )
 	: m_framer( 0, '\0', '\n', '\0', false )
 	, m_deframer( 0, ' ' )
 	, m_processor( cmdlist, m_deframer, m_framer, lock )

--- a/src/Cpl/TShell/Maker.h
+++ b/src/Cpl/TShell/Maker.h
@@ -43,7 +43,7 @@ public:
 	/** Constructor.  The application is responsible for supplying the set of commands and the mutex to ensure atomic
 		output.
 	 */
-	Maker( Cpl::Container::Map<Command>& cmdlist, Cpl::System::Mutex& lock=Cpl::System::Locks_::tracingOutput() );
+	Maker( Cpl::Container::SList<Command>& cmdlist, Cpl::System::Mutex& lock=Cpl::System::Locks_::tracingOutput() );
 
 
 public:

--- a/src/Cpl/TShell/PolledMaker.cpp
+++ b/src/Cpl/TShell/PolledMaker.cpp
@@ -16,7 +16,7 @@ using namespace Cpl::TShell;
 
 
 ////////////////////////////////
-PolledMaker::PolledMaker( Cpl::Container::Map<Command>& cmdlist, Cpl::System::Mutex& lock )
+PolledMaker::PolledMaker( Cpl::Container::SList<Command>& cmdlist, Cpl::System::Mutex& lock )
 	: m_framer( 0, '\0', '\n', '\0', false )
 	, m_deframer( 0, ' ', false )
 	, m_processor( cmdlist, m_deframer, m_framer, lock )

--- a/src/Cpl/TShell/PolledMaker.h
+++ b/src/Cpl/TShell/PolledMaker.h
@@ -43,7 +43,7 @@ public:
 	/** Constructor.  The application is responsible for supplying the set of commands and the mutex to ensure atomic
 		output.
 	 */
-	PolledMaker( Cpl::Container::Map<Command>& cmdlist, Cpl::System::Mutex& lock=Cpl::System::Locks_::tracingOutput() );
+	PolledMaker( Cpl::Container::SList<Command>& cmdlist, Cpl::System::Mutex& lock=Cpl::System::Locks_::tracingOutput() );
 
 
 public:

--- a/src/Cpl/TShell/PolledProcessor.cpp
+++ b/src/Cpl/TShell/PolledProcessor.cpp
@@ -17,7 +17,7 @@ using namespace Cpl::TShell;
 
 
 ///////////////////////////////////
-PolledProcessor::PolledProcessor( Cpl::Container::Map<Command>&     commands,
+PolledProcessor::PolledProcessor( Cpl::Container::SList<Command>&     commands,
 	Cpl::Text::Frame::StreamDecoder&  deframer,
 	Cpl::Text::Frame::StreamEncoder&  framer,
 	Cpl::System::Mutex&               outputLock,

--- a/src/Cpl/TShell/PolledProcessor.h
+++ b/src/Cpl/TShell/PolledProcessor.h
@@ -50,7 +50,7 @@ public:
 		@param initialPermissionLevel   The initial minimum permission level that a user needs to issue command(s)
 
 	 */
-	PolledProcessor( Cpl::Container::Map<Command>&     commands,
+	PolledProcessor( Cpl::Container::SList<Command>&     commands,
 					 Cpl::Text::Frame::StreamDecoder&  deframer,
 					 Cpl::Text::Frame::StreamEncoder&  framer,
 					 Cpl::System::Mutex&               outputLock,

--- a/src/Cpl/TShell/_0test/helpers.h
+++ b/src/Cpl/TShell/_0test/helpers.h
@@ -107,7 +107,7 @@ public:
 
 public:
 	/// Constructor
-	Bob( Cpl::Container::Map<Cpl::TShell::Command>& commandList, Apple& application, Cpl::TShell::Security::Permission_T minPerm = Cpl::TShell::Security::ePUBLIC ) noexcept
+	Bob( Cpl::Container::SList<Cpl::TShell::Command>& commandList, Apple& application, Cpl::TShell::Security::Permission_T minPerm = Cpl::TShell::Security::ePUBLIC ) noexcept
 		:Command( commandList, "bob", minPerm )
 		, m_app( application )
 	{

--- a/src/Cpl/TShell/_0test/statics.h
+++ b/src/Cpl/TShell/_0test/statics.h
@@ -15,7 +15,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern Cpl::Container::Map<Cpl::TShell::Command>   cmdlist;
+extern Cpl::Container::SList<Cpl::TShell::Command>   cmdlist;
 
 static Cpl::TShell::Maker cmdProcessor_( cmdlist );
 

--- a/tests/Cpl/Dm/TShell/_0test/linux/main.cpp
+++ b/tests/Cpl/Dm/TShell/_0test/linux/main.cpp
@@ -10,7 +10,7 @@ extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 Cpl::Io::Stdio::StdIn   infd_;
 Cpl::Io::Stdio::StdOut  outfd_;
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/Dm/TShell/_0test/windows/main.cpp
+++ b/tests/Cpl/Dm/TShell/_0test/windows/main.cpp
@@ -14,7 +14,7 @@ Cpl::Io::Stdio::StdIn                           infd_;
 Cpl::Io::Stdio::StdOut                          outfd_;
 
 // Note: this is global variable for test purposes
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 
 // HACK: to reuse a common test file
 #ifndef BUILD_VARIANT_CPP11

--- a/tests/Cpl/Io/File/Littlefs/TShell/_0test/main.cpp
+++ b/tests/Cpl/Io/File/Littlefs/TShell/_0test/main.cpp
@@ -4,7 +4,7 @@
 #include "Cpl/Io/File/Littlefs/Api.h"
 #include "Cpl/Io/Serial/PhonyStdio/InputOutput.h"
 #include "Cpl/TShell/Command.h"
-#include "Cpl/Container/Map.h"
+#include "Cpl/Container/SList.h"
 #include "Cpl/System/Shutdown.h"
 //#include <signal.h>
 
@@ -20,7 +20,7 @@ Cpl::Io::Serial::PhonyStdio::InputOutput fd_;
 extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 // Note: this is global variable for test purposes
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 
 #define ERASE_SIZE       4096
 #define NUM_ERASE_BLOCKS 128

--- a/tests/Cpl/Logging/TShell/_0test/linux/gcc/main.cpp
+++ b/tests/Cpl/Logging/TShell/_0test/linux/gcc/main.cpp
@@ -10,7 +10,7 @@ extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 Cpl::Io::Stdio::StdIn   infd_;
 Cpl::Io::Stdio::StdOut  outfd_;
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/MApp/_0test/linux/main.cpp
+++ b/tests/Cpl/MApp/_0test/linux/main.cpp
@@ -10,7 +10,7 @@ extern void runtest( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 Cpl::Io::Stdio::StdIn   infd_;
 Cpl::Io::Stdio::StdOut  outfd_;
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/MApp/_0test/windows/main.cpp
+++ b/tests/Cpl/MApp/_0test/windows/main.cpp
@@ -14,7 +14,7 @@ Cpl::Io::Stdio::StdIn                           infd_;
 Cpl::Io::Stdio::StdOut                          outfd_;
 
 // Note: this is a global variable for test purposes
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 
 // HACK: to reuse a common test file
 #ifndef BUILD_VARIANT_CPP11

--- a/tests/Cpl/TShell/Cmd/_0test/linux/gcc/main.cpp
+++ b/tests/Cpl/TShell/Cmd/_0test/linux/gcc/main.cpp
@@ -10,7 +10,7 @@ extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 Cpl::Io::Stdio::StdIn   infd_;
 Cpl::Io::Stdio::StdOut  outfd_;
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/TShell/Cmd/_0test/linux/main.cpp
+++ b/tests/Cpl/TShell/Cmd/_0test/linux/main.cpp
@@ -11,7 +11,7 @@ extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 Cpl::Io::Stdio::StdIn                           infd_;
 Cpl::Io::Stdio::StdOut                          outfd_;
 
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads                  threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/TShell/Cmd/_0test/windows/main.cpp
+++ b/tests/Cpl/TShell/Cmd/_0test/windows/main.cpp
@@ -14,7 +14,7 @@ Cpl::Io::Stdio::StdIn                           infd_;
 Cpl::Io::Stdio::StdOut                          outfd_;
 
 // Note: this is global variable for test purposes
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 
 // HACK: to reuse a common test file
 #ifndef BUILD_VARIANT_CPP11

--- a/tests/Cpl/TShell/_0test/simtick/main.cpp
+++ b/tests/Cpl/TShell/_0test/simtick/main.cpp
@@ -2,7 +2,7 @@
 #include "Cpl/System/Trace.h"
 #include "Cpl/Io/Stdio/StdIn.h"
 #include "Cpl/Io/Stdio/StdOut.h"
-#include "Cpl/Container/Map.h"
+#include "Cpl/Container/SList.h"
 #include "Cpl/TShell/Command.h"
 
 // External references
@@ -10,7 +10,7 @@ extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 Cpl::Io::Stdio::StdIn   infd_;
 Cpl::Io::Stdio::StdOut  outfd_;
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 
 
 int main( int argc, char* const argv[] )

--- a/tests/Cpl/TShell/_0test/test1-phonystdio/linux/gcc/main.cpp
+++ b/tests/Cpl/TShell/_0test/test1-phonystdio/linux/gcc/main.cpp
@@ -8,7 +8,7 @@
 extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 Cpl::Io::Serial::PhonyStdio::InputOutput fd_;
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/TShell/_0test/test1-phonystdio/windows/main.cpp
+++ b/tests/Cpl/TShell/_0test/test1-phonystdio/windows/main.cpp
@@ -12,7 +12,7 @@ extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 Cpl::Io::Serial::PhonyStdio::InputOutput fd_;
 
 // Note: this is global variable for test purposes
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 
 // HACK: to reuse a common test file
 #ifndef BUILD_VARIANT_CPP11

--- a/tests/Cpl/TShell/_0test/test1/linux/gcc/main.cpp
+++ b/tests/Cpl/TShell/_0test/test1/linux/gcc/main.cpp
@@ -10,7 +10,7 @@ extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 Cpl::Io::Stdio::StdIn   infd_;
 Cpl::Io::Stdio::StdOut  outfd_;
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/TShell/_0test/test1/windows/main.cpp
+++ b/tests/Cpl/TShell/_0test/test1/windows/main.cpp
@@ -14,7 +14,7 @@ Cpl::Io::Stdio::StdIn                           infd_;
 Cpl::Io::Stdio::StdOut                          outfd_;
 
 // Note: this is global variable for test purposes
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 
 // HACK: to reuse a common test file
 #ifndef BUILD_VARIANT_CPP11

--- a/tests/Cpl/TShell/_0test/test2/linux/main.cpp
+++ b/tests/Cpl/TShell/_0test/test2/linux/main.cpp
@@ -8,7 +8,7 @@
 extern void shell_test2( Cpl::Io::Socket::Listener& listener );
 
 
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads                  threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/TShell/_0test/test2/windows/main.cpp
+++ b/tests/Cpl/TShell/_0test/test2/windows/main.cpp
@@ -8,7 +8,7 @@
 extern void shell_test2( Cpl::Io::Socket::Listener& listener );
 
 
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads                  threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/TShell/_0test/test4/windows/main.cpp
+++ b/tests/Cpl/TShell/_0test/test4/windows/main.cpp
@@ -9,7 +9,7 @@
 extern void shell_test4( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads                  threadsCmd_( cmdlist );
 static Cpl::Io::Stdio::StdIn  infd_;
 static Cpl::Io::Stdio::StdOut outfd_;

--- a/tests/Cpl/TShell/_0test/test5/linux/gcc/main.cpp
+++ b/tests/Cpl/TShell/_0test/test5/linux/gcc/main.cpp
@@ -10,7 +10,7 @@ extern void shell_test( Cpl::Io::Input& infd, Cpl::Io::Output& outfd );
 
 Cpl::Io::Stdio::StdIn   infd_;
 Cpl::Io::Stdio::StdOut  outfd_;
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 Cpl::TShell::Cmd::Threads threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/TShell/_0test/test5/linux/main.cpp
+++ b/tests/Cpl/TShell/_0test/test5/linux/main.cpp
@@ -15,7 +15,7 @@ Cpl::Io::Stdio::StdIn                           infd_;
 Cpl::Io::Stdio::StdOut                          outfd_;
 
 // Note: this is global variable for test purposes
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 static Cpl::TShell::Cmd::Threads           threadsCmd_( cmdlist );
 
 

--- a/tests/Cpl/TShell/_0test/test5/windows/main.cpp
+++ b/tests/Cpl/TShell/_0test/test5/windows/main.cpp
@@ -15,7 +15,7 @@ Cpl::Io::Stdio::StdIn                           infd_;
 Cpl::Io::Stdio::StdOut                          outfd_;
 
 // Note: this is global variable for test purposes
-Cpl::Container::Map<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
+Cpl::Container::SList<Cpl::TShell::Command>  cmdlist( "ignore_this_parameter-used to invoke the static constructor" );
 
 // HACK: to reuse a common test file
 #ifndef BUILD_VARIANT_CPP11

--- a/xsrc/README.md
+++ b/xsrc/README.md
@@ -1,0 +1,43 @@
+# Outcast
+The contents of this directory are external repositories that have been 
+'copied' into the colony.core repo using the [Outcast tool](https://github.com/johnttaylor/Outcast).  The external repos are copied 'as is' and no additional modifications are needed - except for those listed below
+
+## Manual Edits
+### catch2
+The Catch2 +v3.x unit test framework is used automated unit testing by the
+colony.core repository.  The following file needs to be created and store in the `xsrc/catch2` directory tree
+
+File: `xsrc/catch2/src/catch2/catch_user_config.hpp`
+
+Contents:
+```
+#ifndef CATCH_USER_CONFIG_HPP_INCLUDED
+#define CATCH_USER_CONFIG_HPP_INCLUDED
+
+// Stripped down catch configuration file.
+
+#define CATCH_CONFIG_DEFAULT_REPORTER "console"
+#define CATCH_CONFIG_CONSOLE_WIDTH    80
+
+#endif  // CATCH_USER_CONFIG_HPP_INCLUDED
+```
+
+### littlefs
+Littlefs supports running on a Host (e.g. Linux, Windows) and using the host's underlying file system for its block driver. To enable building littlefs using the Microsoft compiler without warnings, the following edits need to be made
+
+File: `xsrc/littlefs/lfs.c` - Add the following #ifdef at the top of the file
+      
+```
+// EDIT: JTT - Added this to suppress warning when using the Visual Studio compiler
+#ifdef _MSC_VER
+#pragma warning( disable : 4244 4804 )
+#endif
+```
+
+File: `xsrc/littlefs/lfs_utils.h` - Add the following #ifdef at the top of the file
+```
+// EDIT: JTT - Added this to suppress warning when using the Visual Studio compiler
+#ifdef _MSC_VER
+#pragma warning( disable : 4146 )
+#endif
+```            


### PR DESCRIPTION
### Refactor TShell/MApp
- Use a SList instead of Map - smaller ROM/RAM footprint
- **IS A BREAKING CHANGE**

###Maintenance
- SList - prevent potential stack overflow
- Document necessary edits to the Little FS repo (when using the Microsoft compiler)
- Prevent fatal-error-infinite-loop when a unit test failure occurs
- Fix race condition on UART driver
- Fix bug in BitArray base class
